### PR TITLE
Discord Bridge Bot setup

### DIFF
--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -92,6 +92,7 @@ bridgebot:
   hub_id: 0 # numeric Hub ID where Bridgebot will reside
   area_id: 0 # numeric Area ID where Bridgebot will talk
   prefix: "}}}[√Dis√] {" # prefix to use before in-character message, usually to identify this message as Bridgebot one
+  tickspeed: 0.25 # how often does the Discord Bridge send the IC message piles to Discord in seconds. Cannot be lower than 0.1 (one tenth of a second)
 
 # Whether or not Discord webhooks are enabled, and if they are, the webhook URL to use.
 # If webhooks_enabled is set to false, no webhooks will function regardless of whether they are enabled or not.

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -87,6 +87,8 @@ bridgebot_token: string1234
 bridgebot_channel: ao2-lobby
 bridgebot_character: Ponco
 bridgebot_emote: normal
+# The base folder URL to seek for the bridgebot to obtain stuff like character avatar graphics etc.
+bridgebot_base_url: http://www.example.com/base/
 
 # Whether or not Discord webhooks are enabled, and if they are, the webhook URL to use.
 # If webhooks_enabled is set to false, no webhooks will function regardless of whether they are enabled or not.

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -80,6 +80,14 @@ max_chars: 256
 # If true, restrict background selection to the backgrounds.yaml
 use_backgrounds_yaml: true
 
+# Set up a Discord Bridge bot that keeps track of user messages on both ends (AO2 and Discord).
+# Tutorial pending.
+bridgebot_enabled: true
+bridgebot_token: string1234
+bridgebot_channel: ao2-lobby
+bridgebot_character: Ponco
+bridgebot_emote: normal
+
 # Whether or not Discord webhooks are enabled, and if they are, the webhook URL to use.
 # If webhooks_enabled is set to false, no webhooks will function regardless of whether they are enabled or not.
 webhooks_enabled: false

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -81,14 +81,17 @@ max_chars: 256
 use_backgrounds_yaml: true
 
 # Set up a Discord Bridge bot that keeps track of user messages on both ends (AO2 and Discord).
-# Tutorial pending.
-bridgebot_enabled: true
-bridgebot_token: string1234
-bridgebot_channel: ao2-lobby
-bridgebot_character: Ponco
-bridgebot_emote: normal
-# The base folder URL to seek for the bridgebot to obtain stuff like character avatar graphics etc.
-bridgebot_base_url: http://www.example.com/base/
+bridgebot:
+  enabled: true # Whether or not this bot is enabled
+  token: string1234 # Discord Token for the bot
+  channel: ao2-lobby # channel to set up a bridge with
+  character: Ponco # character folder for Bridgebot to use
+  emote: normal # idle emote for Bridgebot to use
+  pos: jur # position Bridgebot will use when talking
+  base_url: http://www.example.com/base/ # base folder URL to seek for bridgebot to obtain stuff like character avatar graphics etc.
+  hub_id: 0 # numeric Hub ID where Bridgebot will reside
+  area_id: 0 # numeric Area ID where Bridgebot will talk
+  prefix: "}}}[√Dis√] {" # prefix to use before in-character message, usually to identify this message as Bridgebot one
 
 # Whether or not Discord webhooks are enabled, and if they are, the webhook URL to use.
 # If webhooks_enabled is set to false, no webhooks will function regardless of whether they are enabled or not.

--- a/server/discordbot.py
+++ b/server/discordbot.py
@@ -63,4 +63,4 @@ class Bridgebot(commands.Bot):
         await self.process_commands(message)
 
 if __name__ == '__main__':
-    Bridgebot.init(None, 'NzIxNzczNDA3Njc0NTY0NzQ5.XuZZ3g.uDoZ08NhNG4juziAjK_bYAQz_eE')
+    Bridgebot.init(None, 'LOL IMAGINE POSTING YOUR TOKEN')

--- a/server/discordbot.py
+++ b/server/discordbot.py
@@ -52,6 +52,9 @@ class Bridgebot(commands.Bot):
             return
 
         if not message.content.startswith('$'):
+            if len(message.clean_content) > 256:
+                await self.channel.send('Your message was too long - it was not received by the client. (The limit is 256 characters)')
+                return
             self.server.send_discord_chat(message.author.name, escape_markdown(message.clean_content), self.hub_id, self.area_id)
 
         # await self.process_commands(message)

--- a/server/discordbot.py
+++ b/server/discordbot.py
@@ -9,12 +9,12 @@ class Bridgebot(commands.Bot):
     """
     The AO2 Discord bridge self.
     """
-    def __init__(self, server, target_chanel):
+    def __init__(self, server, target_chanel, hub_id, area_id):
         super().__init__(command_prefix='$')
         self.server = server
         self.pending_messages = []
-        self.hub_id = 0
-        self.area_id = 0
+        self.hub_id = hub_id
+        self.area_id = area_id
         self.target_channel = target_chanel
 
     @staticmethod
@@ -23,9 +23,9 @@ class Bridgebot(commands.Bot):
         loop.close()
 
     @classmethod
-    async def init(self, server, token=None, target_channel='general'):
+    async def init(self, server, token=None, target_channel='general', hub_id=0, area_id=0):
         '''Starts the actual bot'''
-        new = self(server, target_channel)
+        new = self(server, target_channel, hub_id, area_id)
         server.bridgebot = new
         print('Trying to start the Discord Bridge bot...')
         try:

--- a/server/discordbot.py
+++ b/server/discordbot.py
@@ -35,8 +35,12 @@ class Bridgebot(commands.Bot):
             raise
     
     def queue_message(self, name, message, charname):
-        base = self.server.config["bridgebot_base_url"]
-        avatar_url = base + parse.quote("characters/" + charname + "/char_icon.png")
+        base = None
+        avatar_url = None
+        if "bridgebot_base_url" in self.server.config:
+            base = self.server.config["bridgebot_base_url"]
+        if base != None:
+            avatar_url = base + parse.quote("characters/" + charname + "/char_icon.png")
         self.pending_messages.append([name, message, avatar_url])
 
     async def on_ready(self):

--- a/server/discordbot.py
+++ b/server/discordbot.py
@@ -63,7 +63,11 @@ class Bridgebot(commands.Bot):
             return
 
         if not message.content.startswith('$'):
-            if len(message.clean_content) > 256:
+            try:
+                max_char = int(self.server.config['max_chars'])
+            except:
+                max_char = 256
+            if len(message.clean_content) > max_char:
                 await self.channel.send('Your message was too long - it was not received by the client. (The limit is 256 characters)')
                 return
             self.server.send_discord_chat(message.author.name, escape_markdown(message.clean_content), self.hub_id, self.area_id)

--- a/server/discordbot.py
+++ b/server/discordbot.py
@@ -1,3 +1,4 @@
+from urllib import parse
 import asyncio
 import discord
 from discord.ext import commands
@@ -19,6 +20,7 @@ class Bridgebot(commands.Bot):
     @staticmethod
     def loop_it_forever(loop):
         loop.run_forever()
+        loop.close()
 
     @classmethod
     async def init(self, server, token=None, target_channel='general'):
@@ -34,7 +36,7 @@ class Bridgebot(commands.Bot):
     
     def queue_message(self, name, message, charname):
         base = self.server.config["bridgebot_base_url"]
-        avatar_url = f"{base}characters/{charname}/char_icon.png"
+        avatar_url = base + parse.quote("characters/" + charname + "/char_icon.png")
         self.pending_messages.append([name, message, avatar_url])
 
     async def on_ready(self):

--- a/server/discordbot.py
+++ b/server/discordbot.py
@@ -1,0 +1,66 @@
+import asyncio
+import discord
+from discord.ext import commands
+from discord.errors import Forbidden, HTTPException
+
+class Bridgebot(commands.Bot):
+    """
+    The AO2 Discord bridge self.
+    """
+    def __init__(self, server):
+        super().__init__(command_prefix='$')
+        self.server = server
+
+    @classmethod
+    def init(bot, server, token=None):
+        '''Starts the actual bot'''
+        new = bot(server)
+        try:
+            new.run(token)
+        except Exception as e:
+            print(e)
+
+    async def on_ready(self, ):
+        print('Successfully logged in.')
+        print('Username -> ' + self.user.name)
+        print('ID -> ' + str(self.user.id))
+        self.guild = self.guilds[0]
+        channel = discord.utils.get(self.guild.text_channels, name='ao2-listener')
+        await channel.send('Hi I exist now')
+
+    async def on_message(self, message):
+        if message.content.startswith('thumb me up scotty'):
+            channel = message.channel
+            await channel.send('Send me that 👍 reaction, mate')
+
+            def check(reaction, user):
+                return user == message.author and str(reaction.emoji) == '👍'
+
+            try:
+                reaction, user = await self.wait_for('reaction_add', timeout=5.0, check=check)
+            except asyncio.TimeoutError:
+                await channel.send('👎')
+            else:
+                await channel.send('👍')
+
+        if message.content.startswith('webhook test'):
+            channel = message.channel
+            webhook = None
+            try:
+                webhooks = await channel.webhooks()
+                for hook in webhooks:
+                    if hook.user == self.user:
+                        webhook = hook
+                        break
+                if webhook == None:
+                    webhook = await channel.create_webhook(name='AO2_Bridgebot')
+                await webhook.send('Hello World', username='Foo')#, avatar_url='https://cdn.discordapp.com/attachments/721774936649367644/743714648632721459/Button1_off.png')
+            except Forbidden:
+                await channel.send('Insufficient permissions.')
+            except HTTPException:
+                await channel.send('HTTP failure.')
+
+        await self.process_commands(message)
+
+if __name__ == '__main__':
+    Bridgebot.init(None, 'NzIxNzczNDA3Njc0NTY0NzQ5.XuZZ3g.uDoZ08NhNG4juziAjK_bYAQz_eE')

--- a/server/discordbot.py
+++ b/server/discordbot.py
@@ -25,10 +25,14 @@ class Bridgebot(commands.Bot):
         print('Username -> ' + self.user.name)
         print('ID -> ' + str(self.user.id))
         self.guild = self.guilds[0]
-        channel = discord.utils.get(self.guild.text_channels, name='ao2-listener')
-        await channel.send('Hi I exist now')
+        self.channel = discord.utils.get(self.guild.text_channels, name='ao2-listener')
+        await self.channel.send('Hi I exist now')
 
     async def on_message(self, message):
+        # don't process our own messages
+        if message.author == self:
+            return
+
         if message.content.startswith('thumb me up scotty'):
             channel = message.channel
             await channel.send('Send me that 👍 reaction, mate')
@@ -44,23 +48,25 @@ class Bridgebot(commands.Bot):
                 await channel.send('👍')
 
         if message.content.startswith('webhook test'):
-            channel = message.channel
-            webhook = None
-            try:
-                webhooks = await channel.webhooks()
-                for hook in webhooks:
-                    if hook.user == self.user:
-                        webhook = hook
-                        break
-                if webhook == None:
-                    webhook = await channel.create_webhook(name='AO2_Bridgebot')
-                await webhook.send('Hello World', username='Foo')#, avatar_url='https://cdn.discordapp.com/attachments/721774936649367644/743714648632721459/Button1_off.png')
-            except Forbidden:
-                await channel.send('Insufficient permissions.')
-            except HTTPException:
-                await channel.send('HTTP failure.')
+            await self.send_char_message('Foo', 'Hello World', 'https://cdn.discordapp.com/attachments/721774936649367644/743714648632721459/Button1_off.png')
 
         await self.process_commands(message)
+    
+    async def send_char_message(self, name, message, avatar=''):
+        webhook = None
+        try:
+            webhooks = await self.channel.webhooks()
+            for hook in webhooks:
+                if hook.user == self.user:
+                    webhook = hook
+                    break
+            if webhook == None:
+                webhook = await self.channel.create_webhook(name='AO2_Bridgebot')
+            await webhook.send(message, username=name, avatar_url=avatar)
+        except Forbidden:
+            await self.channel.send('Insufficient permissions.')
+        except HTTPException:
+            await self.channel.send('HTTP failure.')
 
 if __name__ == '__main__':
-    Bridgebot.init(None, 'LOL IMAGINE POSTING YOUR TOKEN')
+    Bridgebot.init(None, 'NzIxNzczNDA3Njc0NTY0NzQ5.XuZZ3g.XRHqqMUYJgJWP1X1rD8Lfn_mPnU')

--- a/server/discordbot.py
+++ b/server/discordbot.py
@@ -33,7 +33,9 @@ class Bridgebot(commands.Bot):
             raise
     
     def queue_message(self, name, message, charname):
-        self.pending_messages.append([name, message, None])
+        base = self.server.config["bridgebot_base_url"]
+        avatar_url = f"{base}characters/{charname}/char_icon.png"
+        self.pending_messages.append([name, message, avatar_url])
 
     async def on_ready(self):
         print('Discord Bridge Successfully logged in.')

--- a/server/discordbot.py
+++ b/server/discordbot.py
@@ -67,6 +67,3 @@ class Bridgebot(commands.Bot):
             await self.channel.send('Insufficient permissions.')
         except HTTPException:
             await self.channel.send('HTTP failure.')
-
-if __name__ == '__main__':
-    Bridgebot.init(None, 'NzIxNzczNDA3Njc0NTY0NzQ5.XuZZ3g.XRHqqMUYJgJWP1X1rD8Lfn_mPnU')

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -717,6 +717,26 @@ class AOProtocol(asyncio.Protocol):
                 self.client.hide(False)
                 self.client.area.broadcast_area_list(self.client)
 
+            # Discord Bridgebot
+            if 'bridgebot_enabled' in self.server.config and self.server.config['bridgebot_enabled'] and \
+                  self.client.area.area_manager.id == self.server.bridgebot.hub_id and self.client.area.id == self.server.bridgebot.area_id:
+                webname = self.client.char_name
+                if showname != self.server.char_list[cid]:
+                    webname = f'{showname} ({webname})'
+                # you'll hate me for this
+                text = msg.replace('}', '').replace('{', '').replace('`', '').replace('|', '').replace('~', '').replace('º', '').replace('№', '').replace('√', '').replace('\\s', '').replace('\\f', '')
+                # escape chars
+                text = text.replace('@', '@\u200b') # The only way to escape a Discord ping is a zero width space...
+                text = text.replace('<num>', '\\#')
+                text = text.replace('<and>', '&')
+                text = text.replace('*', '\\*')
+                text = text.replace('_', '\\_')
+                # String is empty if we're strippin
+                if not text.strip():
+                    # Discord blankpost
+                    text = '_ _'
+                self.server.bridgebot.queue_message(webname, text, self.client.char_name)
+
         # Additive only works on same-char messages
         if self.client.area.last_ic_message == None or cid != self.client.area.last_ic_message[8]:
             additive = 0

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -718,7 +718,7 @@ class AOProtocol(asyncio.Protocol):
                 self.client.area.broadcast_area_list(self.client)
 
             # Discord Bridgebot
-            if 'bridgebot_enabled' in self.server.config and self.server.config['bridgebot']['enabled'] and \
+            if 'bridgebot' in self.server.config and self.server.config['bridgebot']['enabled'] and \
                   self.client.area.area_manager.id == self.server.bridgebot.hub_id and self.client.area.id == self.server.bridgebot.area_id:
                 webname = self.client.char_name
                 if showname != '' and showname != self.server.char_list[cid]:

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -721,7 +721,7 @@ class AOProtocol(asyncio.Protocol):
             if 'bridgebot_enabled' in self.server.config and self.server.config['bridgebot_enabled'] and \
                   self.client.area.area_manager.id == self.server.bridgebot.hub_id and self.client.area.id == self.server.bridgebot.area_id:
                 webname = self.client.char_name
-                if showname != self.server.char_list[cid]:
+                if showname != '' and showname != self.server.char_list[cid]:
                     webname = f'{showname} ({webname})'
                 # you'll hate me for this
                 text = msg.replace('}', '').replace('{', '').replace('`', '').replace('|', '').replace('~', '').replace('º', '').replace('№', '').replace('√', '').replace('\\s', '').replace('\\f', '')

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -718,7 +718,7 @@ class AOProtocol(asyncio.Protocol):
                 self.client.area.broadcast_area_list(self.client)
 
             # Discord Bridgebot
-            if 'bridgebot_enabled' in self.server.config and self.server.config['bridgebot_enabled'] and \
+            if 'bridgebot_enabled' in self.server.config and self.server.config['bridgebot']['enabled'] and \
                   self.client.area.area_manager.id == self.server.bridgebot.hub_id and self.client.area.id == self.server.bridgebot.area_id:
                 webname = self.client.char_name
                 if showname != '' and showname != self.server.char_list[cid]:

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -137,9 +137,9 @@ class TsuServer3:
         if self.config['use_backgrounds_yaml']:
             self.use_backgrounds_yaml = True
 
-        if self.config['bridgebot_enabled']:
+        if 'bridgebot' in self.config and self.config['bridgebot']['enabled']:
             loop2 = asyncio.new_event_loop()
-            loop2.create_task(Bridgebot.init(self, self.config['bridgebot_token'], self.config['bridgebot_channel']))
+            loop2.create_task(Bridgebot.init(self, self.config['bridgebot']['token'], self.config['bridgebot']['channel'], self.config['bridgebot']['hub_id'], self.config['bridgebot']['area_id']))
             thread = threading.Thread(target=Bridgebot.loop_it_forever, args=(loop2,))
             thread.start()
 
@@ -468,13 +468,13 @@ class TsuServer3:
 
     def send_discord_chat(self, name, message, hub_id=0, area_id=0):
         area = self.hub_manager.get_hub_by_id(hub_id).get_area_by_id(area_id)
-        cid = self.get_char_id_by_name(self.config['bridgebot_character'])
+        cid = self.get_char_id_by_name(self.config['bridgebot']['character'])
         message = remove_URL(message)
         message = message.replace('}', '\\}').replace('{', '\\{').replace('`', '\\`').replace('|', '\\|').replace('~', '\\~').replace('º', '\\º').replace('№', '\\№').replace('√', '\\√').replace('\\s', '').replace('\\f', '')
-        message = "}}}[√Dis√] {" + message
+        message = self.config['bridgebot']['prefix'] + message
         if len(name) > 14:
             name = name[:14].rstrip() + '.'
-        area.send_ic(None, '1', 0, self.config['bridgebot_character'], self.config['bridgebot_emote'], message, 'jur', "", 0, cid, 0, 0, [0], 0, 0, 0, name, -1, "", "", 0, 0, 0, 0, "0", 0, "", "", "", 0, "")
+        area.send_ic(None, '1', 0, self.config['bridgebot']['character'], self.config['bridgebot']['emote'], message, self.config['bridgebot']['pos'], "", 0, cid, 0, 0, [0], 0, 0, 0, name, -1, "", "", 0, 0, 0, 0, "0", 0, "", "", "", 0, "")
 
     def refresh(self):
         """

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -36,11 +36,13 @@ from server import database
 from server.hub_manager import HubManager
 from server.client_manager import ClientManager
 from server.emotes import Emotes
+from server.discordbot import Bridgebot
 from server.exceptions import ClientError,ServerError
 from server.network.aoprotocol import AOProtocol
 from server.network.aoprotocol_ws import new_websocket_client
 from server.network.masterserverclient import MasterServerClient
 from server.network.webhooks import Webhooks
+from server.constants import remove_URL
 import server.logger
 
 class TsuServer3:
@@ -101,8 +103,15 @@ class TsuServer3:
             sys.exit(1)
 
         self.client_manager = ClientManager(self)
-        self.webhooks = Webhooks(self)
         server.logger.setup_logger(debug=self.config['debug'])
+
+        self.webhooks = Webhooks(self)
+        self.bridgebot = None
+        try:
+            if self.config['bridgebot_enabled']:
+                self.bridgebot = Bridgebot.init(self, self.config['bridgebot_token'])
+        except:
+            print('Discord Bridgebot failed to initialize! Did you configure it properly?')
 
     def start(self):
         """Start the server."""
@@ -454,6 +463,16 @@ class TsuServer3:
                     return
 
         client.send_command('ARUP', *args)
+
+    def send_discord_chat(self, name, message, hub_id=0, area_id=0):
+        area = self.hub_manager.get_hub_by_id(hub_id).get_area_by_id(area_id)
+        showname = 'Discord'
+        cid = self.get_char_id_by_name(self.config['bridgebot_character'])
+        message = remove_URL(message)
+        message = message.replace('}', '').replace('{', '').replace('`', '').replace('|', '').replace('~', '').replace('º', '').replace('№', '').replace('√', '').replace('\\s', '').replace('\\f', '')
+        message = "}}}" + f'{name}: {message}'
+        
+        area.send_ic(None, '1', 0, self.config['bridgebot_character'], self.config['bridgebot_emote'], message, 'jur', "", 0, cid, 0, 0, [0], 0, 0, 0, showname, -1, "", "", 0, 0, 0, 0, "0", 0, "", "", "", 0, "")
 
     def refresh(self):
         """

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -22,7 +22,6 @@ import os
 import importlib
 
 import asyncio
-import threading
 import websockets
 
 import geoip2.database
@@ -138,10 +137,8 @@ class TsuServer3:
             self.use_backgrounds_yaml = True
 
         if 'bridgebot' in self.config and self.config['bridgebot']['enabled']:
-            loop2 = asyncio.new_event_loop()
-            loop2.create_task(Bridgebot.init(self, self.config['bridgebot']['token'], self.config['bridgebot']['channel'], self.config['bridgebot']['hub_id'], self.config['bridgebot']['area_id']))
-            thread = threading.Thread(target=Bridgebot.loop_it_forever, args=(loop2,))
-            thread.start()
+            self.bridgebot = Bridgebot(self, self.config['bridgebot']['channel'], self.config['bridgebot']['hub_id'], self.config['bridgebot']['area_id'])
+            asyncio.ensure_future(self.bridgebot.init(self.config['bridgebot']['token']), loop=loop)
 
         asyncio.ensure_future(self.schedule_unbans())
 

--- a/start_server.py
+++ b/start_server.py
@@ -34,7 +34,7 @@ def check_deps():
         sys.exit(1)
 
     try:
-        import oyaml
+        import discord
     except ModuleNotFoundError:
         print('Installing dependencies for you...')
         try:


### PR DESCRIPTION
Introduces a very robust integarted Discord Bridge to KFO-Server. Features include:
 - Webhook-based representation of speaking characters in the selected channel
 - Setup isn't too difficult, requires you to obtain a Discord Bot according to [this guide](https://discordpy.readthedocs.io/en/latest/discord.html)
 - Do not give the bot any permissions - the bot only needs permissions to the one channel you intend to use for the bridge. The channel permissions the bot needs are "read messages", "send messages" and "manage webhooks".
 - Set up the config.yaml properly. `bridgebot_token` is your Discord Bot token, `bridgebot_channel` is the channel on your Discord for the bot to access, `bridgebot_character` is the on-server character folder to use, `bridgebot_emote` is the emote of said character to use, and optional `bridgebot_base_url` is the content repository for your server that you use for WebAO integration. If you supply the base_url, the Bridgebot will use character's `char_icon.png` for the avatar every time that character speaks.
 - If you did everything correctly, once you start up the server, you have properly established a two-way link between your Discord and your targeted area. Congratulations!