### PR TITLE
Add /follow_me command.

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -119,6 +119,7 @@ class ClientManager:
             self.sneaking = False
             self.listen_pos = None
             self.following = None
+            self.forced_to_follow = False
             self.edit_ambience = False
 
             # 0 = listen to NONE

--- a/server/commands/hubs.py
+++ b/server/commands/hubs.py
@@ -592,6 +592,8 @@ def ooc_cmd_follow_me(client, arg):
         raise ArgumentError("You must specify a target. Use /follow_me <id>.")
     if targets:
         for c in targets:
+            if client == c:
+                raise ClientError("You are already forced to follow yourself because you are yourself!")
             c.following = client
             c.forced_to_follow = True
             c.send_ooc(f"You've been forced to follow {client.showname}!")

--- a/server/commands/hubs.py
+++ b/server/commands/hubs.py
@@ -609,6 +609,8 @@ def ooc_cmd_follow(client, arg):
     Follow targeted character ID.
     Usage: /follow [id]
     """
+    if client.forced_to_follow and not client.is_mod and client not in client.area.area_manager.owners:
+        raise ClientError(f"You can't change follow targets while being forced to follow!")
     if len(arg) == 0:
         try:
             client.send_ooc(

--- a/server/commands/hubs.py
+++ b/server/commands/hubs.py
@@ -598,7 +598,7 @@ def ooc_cmd_follow_me(client, arg):
             c.forced_to_follow = True
             c.send_ooc(f"You've been forced to follow {client.showname}!")
             if c.area != client.area:
-                c.change_area(client.area)
+                c.set_area(client.area)
         client.send_ooc(f"Forced {len(targets)} existing client(s) to follow you.")
     else:
         client.send_ooc("No targets found.")


### PR DESCRIPTION
Referencing this suggestion (bit old):

![image](https://user-images.githubusercontent.com/30537683/153114841-54bbd388-2bfc-441c-a548-2f2c21fb816c.png)

The /follow_me command forces a chosen user, if you're a mod or the hub owner, to follow you, and drags them into the same area as you. The /unfollow command was also changed such that users who were forced to follow someone cannot escape being followed, and /follow was changed such that users who were forced cannot change follow targets midway.

This probably suffers from the same issues of the follow command tagging onto a new person upon a disconnect (if that's still an issue), but otherwise it works fine.

I tested it multiple times and it works as intended for the general case. Let me know if something is missing.