### PR TITLE
Add /toggle_passingmsg command

### DIFF
--- a/server/area.py
+++ b/server/area.py
@@ -163,6 +163,8 @@ class Area:
         self.pos_dark = "wit"
         # The desc to set when the area's lights are turned off
         self.desc_dark = "It's pitch black in here, you can't see a thing!"
+        # Sends a message to the IC when changing areas
+        self.passing_msg = False
         # /prefs end
 
         # DR minigames
@@ -459,6 +461,8 @@ class Area:
             self.pos_dark = area["pos_dark"]
         if "desc_dark" in area:
             self.desc_dark = area["desc_dark"]
+        if 'passing_msg' in area:
+            self.passing_msg = area['passing_msg']
 
         if "evidence" in area and len(area["evidence"]) > 0:
             self.evi_list.evidences.clear()
@@ -560,6 +564,7 @@ class Area:
         area["background_dark"] = self.background_dark
         area["pos_dark"] = self.pos_dark
         area["desc_dark"] = self.desc_dark
+        area["passing_msg"] = self.passing_msg
         if len(self.evi_list.evidences) > 0:
             area["evidence"] = [e.to_dict() for e in self.evi_list.evidences]
         if len(self.links) > 0:

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -126,6 +126,7 @@ class AreaManager:
         self.censor_ooc = True
         self.can_spectate = True
         self.can_getareas = True
+        self.passing_msg = False
         # /prefs
 
         # optimization memes
@@ -206,6 +207,7 @@ class AreaManager:
             "censor_ooc",
             "can_spectate",
             "can_getareas",
+            "passing_msg",
         ]
         for entry in list(set(load_list) - set(ignore)):
             if entry in hub:
@@ -260,6 +262,7 @@ class AreaManager:
             "censor_ooc",
             "can_spectate",
             "can_getareas",
+            "passing_msg",
         ]
         for entry in list(set(save_list) - set(ignore)):
             hub[entry] = getattr(self, entry)

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -865,10 +865,8 @@ class ClientManager:
                 if not old_area.dark and not old_area.force_sneak:
                     if old_area.area_manager == self.area.area_manager:
                         if self.area.area_manager.passing_msg == True:
-                            if showname == '':
-                                showname = self.char_name
                             old_area.send_ic(
-                                None, '1', 1, "", "", f'~~[º{self.showname}º leaves to º{area.name}º.]', 
+                                None, '1', 1, "", "", f'~~}}[º{self.showname}º leaves to º{area.name}º.]', 
                                 "", "", 1, -1, 0, 0, [0], 0, 0, 0, "", -1, "", "", 0, 0, 0, 0, "0", 0, "", "", "", 0, ""
                             )
                         for c in old_area.clients:
@@ -913,10 +911,8 @@ class ClientManager:
                         "1",
                     )
                     if self.area.area_manager.passing_msg == True:
-                        if showname == '':
-                            showname = self.char_name
                         self.area.send_ic(
-                            None, '1', 1, "", "", f'~~[º{self.showname}º enters from º{old_area.name}º.]', 
+                            None, '1', 1, "", "", f'~~}}[º{self.showname}º enters from º{old_area.name}º.]', 
                             "", "", 1, -1, 0, 0, [0], 0, 0, 0, "", -1, "", "", 0, 0, 0, 0, "0", 0, "", "", "", 0, ""
                         )
                 else:

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -865,6 +865,17 @@ class ClientManager:
                 if not old_area.dark and not old_area.force_sneak:
                     if old_area.area_manager == self.area.area_manager:
                         for c in old_area.clients:
+                            if self.area.area_manager.passing_msg == True:
+                                # Prevents a duplicate message when someone leaves
+                                if count > 0:
+                                    break
+                                if showname == '':
+                                    showname = self.char_name
+                                old_area.send_ic(
+                                    None, '1', 1, "", "", f'~~[º{self.showname}º leaves to º{area.name}º.]', 
+                                    "", "", 1, -1, 0, 0, [0], 0, 0, 0, "", -1, "", "", 0, 0, 0, 0, "0", 0, "", "", "", 0, ""
+                                )
+                                count += 1
                             # Check if the GMs should really see this msg
                             if c in old_area.owners and c.remote_listen in [2, 3]:
                                 continue
@@ -905,6 +916,13 @@ class ClientManager:
                         f"[{self.id}] {self.showname} enters from [{old_area.id}] {old_area.name}{desc}",
                         "1",
                     )
+                    if self.area.area_manager.passing_msg == True:
+                        if showname == '':
+                            showname = self.char_name
+                        self.area.send_ic(
+                            None, '1', 1, "", "", f'~~[º{self.showname}º arrives.]', 
+                            "", "", 1, -1, 0, 0, [0], 0, 0, 0, "", -1, "", "", 0, 0, 0, 0, "0", 0, "", "", "", 0, ""
+                        )
                 else:
                     self.area.send_command(
                         "CT",

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -864,18 +864,14 @@ class ClientManager:
             ):
                 if not old_area.dark and not old_area.force_sneak:
                     if old_area.area_manager == self.area.area_manager:
+                        if self.area.area_manager.passing_msg == True:
+                            if showname == '':
+                                showname = self.char_name
+                            old_area.send_ic(
+                                None, '1', 1, "", "", f'~~[º{self.showname}º leaves to º{area.name}º.]', 
+                                "", "", 1, -1, 0, 0, [0], 0, 0, 0, "", -1, "", "", 0, 0, 0, 0, "0", 0, "", "", "", 0, ""
+                            )
                         for c in old_area.clients:
-                            if self.area.area_manager.passing_msg == True:
-                                # Prevents a duplicate message when someone leaves
-                                if count > 0:
-                                    break
-                                if showname == '':
-                                    showname = self.char_name
-                                old_area.send_ic(
-                                    None, '1', 1, "", "", f'~~[º{self.showname}º leaves to º{area.name}º.]', 
-                                    "", "", 1, -1, 0, 0, [0], 0, 0, 0, "", -1, "", "", 0, 0, 0, 0, "0", 0, "", "", "", 0, ""
-                                )
-                                count += 1
                             # Check if the GMs should really see this msg
                             if c in old_area.owners and c.remote_listen in [2, 3]:
                                 continue
@@ -920,7 +916,7 @@ class ClientManager:
                         if showname == '':
                             showname = self.char_name
                         self.area.send_ic(
-                            None, '1', 1, "", "", f'~~[º{self.showname}º arrives.]', 
+                            None, '1', 1, "", "", f'~~[º{self.showname}º enters from º{old_area.name}º.]', 
                             "", "", 1, -1, 0, 0, [0], 0, 0, 0, "", -1, "", "", 0, 0, 0, 0, "0", 0, "", "", "", 0, ""
                         )
                 else:

--- a/server/commands/hubs.py
+++ b/server/commands/hubs.py
@@ -481,12 +481,14 @@ def ooc_cmd_toggle_replace_music(client, arg):
 @mod_only(hub_owners=True)
 def ooc_cmd_toggle_passingmsg(client, arg):
     """
-    Toggle an IC area passing message for this hub.
+    Toggle an IC message when changing areas for this hub.
     Usage: /toggle_passingmsg
     """
     client.area.area_manager.passing_msg = not client.area.area_manager.passing_msg
     toggle = 'enabled' if client.area.area_manager.passing_msg else 'disabled'
-    client.area.area_manager.broadcast_ooc(f'IC area passing messages have been {toggle} for this hub.')
+    client.area.area_manager.broadcast_ooc(
+        f'IC area passing messages are now {toggle} for this hub.'
+    )
 
 @mod_only(hub_owners=True)
 def ooc_cmd_arup_enable(client, arg):

--- a/server/commands/hubs.py
+++ b/server/commands/hubs.py
@@ -32,6 +32,7 @@ __all__ = [
     "ooc_cmd_arup_disable",
     "ooc_cmd_toggle_getareas",
     "ooc_cmd_toggle_spectate",
+    "ooc_cmd_toggle_passingmsg",
     "ooc_cmd_hide_clients",
     "ooc_cmd_unhide_clients",
     # General
@@ -477,6 +478,15 @@ def ooc_cmd_toggle_replace_music(client, arg):
         f"Hub music list will {toggle} replace server music list."
     )
 
+@mod_only(hub_owners=True)
+def ooc_cmd_toggle_passingmsg(client, arg):
+    """
+    Toggle an IC area passing message for this hub.
+    Usage: /toggle_passingmsg
+    """
+    client.area.area_manager.passing_msg = not client.area.area_manager.passing_msg
+    toggle = 'enabled' if client.area.area_manager.passing_msg else 'disabled'
+    client.area.area_manager.broadcast_ooc(f'IC area passing messages have been {toggle} for this hub.')
 
 @mod_only(hub_owners=True)
 def ooc_cmd_arup_enable(client, arg):

--- a/server/commands/hubs.py
+++ b/server/commands/hubs.py
@@ -32,7 +32,7 @@ __all__ = [
     "ooc_cmd_arup_disable",
     "ooc_cmd_toggle_getareas",
     "ooc_cmd_toggle_spectate",
-    "ooc_cmd_toggle_passingmsg",
+    "ooc_cmd_toggle_passing_ic",
     "ooc_cmd_hide_clients",
     "ooc_cmd_unhide_clients",
     # General
@@ -479,10 +479,10 @@ def ooc_cmd_toggle_replace_music(client, arg):
     )
 
 @mod_only(hub_owners=True)
-def ooc_cmd_toggle_passingmsg(client, arg):
+def ooc_cmd_toggle_passing_ic(client, arg):
     """
     Toggle an IC message when changing areas for this hub.
-    Usage: /toggle_passingmsg
+    Usage: /toggle_passing_ic
     """
     client.area.area_manager.passing_msg = not client.area.area_manager.passing_msg
     toggle = 'enabled' if client.area.area_manager.passing_msg else 'disabled'


### PR DESCRIPTION
Pretty much like the already established "_character_ enters from/leaves to..." OOC message, but IC now and togglable for GMs. I couldn't think of a better name for the command, so this is kinda provisional. Also wasn't too sure about "_character_ arrives", so might as well change it if the other way looks better.

![Attorney_Online_oCKa0ayZg4](https://user-images.githubusercontent.com/81326989/153636187-ed0304bf-6411-4fa5-83e2-f030fb570461.png)
![Attorney_Online_Oo0FwDucux](https://user-images.githubusercontent.com/81326989/153637206-3cc55c9a-2c62-4af0-bfdf-333d3d1c44e5.png)
