### PR TITLE
fix refresh command

### DIFF
--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -579,10 +579,11 @@ class TsuServer3:
                             "Your moderator credentials have been revoked.")
             self.config["modpass"] = cfg_yaml["modpass"]
 
+        self.load_config()
         self.load_command_aliases()
         self.load_censors()
-        self.load_characters()
         self.load_iniswaps()
+        self.load_characters()
         self.load_music()
         self.load_backgrounds()
         self.load_ipranges()


### PR DESCRIPTION
it didn't reload the main config file before

that meant you weren't able to change the webhook endpoint without a server restart