### PR TITLE
reset pair on area change

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -734,6 +734,9 @@ class ClientManager:
             # If we're using /evidence_present, reset it due to area change (evidence will be different most likely)
             self.presenting = 0
 
+            # reset pair
+            self.charid_pair = -1
+
             # Make sure the client's available areas are updated
             self.area.broadcast_area_list(self)
 


### PR DESCRIPTION
```
2022-07-10 14:58:17|681025||Newbie Hole|Layton|Namper|NampiGuy|0|0|Vanilla|64|Okay you need a multiclient and be on web
2022-07-10 14:59:15|681025||Newbie Hole|Layton|Namper|NampiGuy|0|0|Vanilla|64|Pair with your own multiclient, make sure you're paired properly.
2022-07-10 14:59:23|681025||Newbie Hole|Layton|Namper|NampiGuy|0|0|Vanilla|64|Go to an area where iniswap is enabled.
2022-07-10 14:59:31|681025||Newbie Hole|Layton|Namper|NampiGuy|0|0|Vanilla|64|And speak with the iniswapped character.
2022-07-10 14:59:41|681025||Newbie Hole|Layton|Namper|NampiGuy|0|0|Vanilla|64|Then put both clients in NH, and speak with the non iniswapped.
2022-07-10 14:59:47|681025||Newbie Hole|Layton|Namper|NampiGuy|0|0|Vanilla|64|And done.
2022-07-10 14:59:54|681025||Newbie Hole|Layton|Namper|NampiGuy|0|0|Vanilla|64|both
2022-07-10 14:59:58|681025||Newbie Hole|Layton|Namper|NampiGuy|0|0|Vanilla|64|to make sure you're paired properly
```