### PR TITLE
New /hpset command

### DIFF
--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -33,7 +33,6 @@ __all__ = [
     "ooc_cmd_whois",
     "ooc_cmd_restart",
     "ooc_cmd_myid",
-    "ooc_cmd_hpset",
 ]
 
 
@@ -545,33 +544,3 @@ def ooc_cmd_myid(client, arg):
     if client.name != "":
         info += f": {client.name}"
     client.send_ooc(info)
-
-
-@mod_only()
-def ooc_cmd_hpset(client, arg):
-    """
-    Set hp.
-    Usage: /hpset <pos> <amount> [area]
-    """
-    args = list(arg.split(" "))
-    if len(args) == 0:
-        raise ArgumentError(
-            "You must specify a position and HP. Use /hpset <pos> <amount> [area]")
-    elif len(args) == 1:
-        raise ArgumentError(
-            "You must specify HP. Use /hpset <pos> <amount> [area]")
-
-    if args[0] == "def":
-        side = 1
-    elif args[0] == "pro":
-        side = 2
-    else:
-        ArgumentError("Invalid position. Use \"pro\" or \"def\"")
-
-    if len(args) == 2:
-        for area in client.area.area_manager.areas:
-            area.change_hp(side, int(args[1]))
-    else:
-        for aid in args[2:]:
-            area = client.area.area_manager.get_area_by_id(int(aid))
-            area.change_hp(side, int(args[1]))

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -3,6 +3,7 @@ import shlex
 import arrow
 import pytimeparse
 
+
 from server import database
 from server.constants import TargetType
 from server.exceptions import ClientError, ServerError, ArgumentError
@@ -32,6 +33,7 @@ __all__ = [
     "ooc_cmd_whois",
     "ooc_cmd_restart",
     "ooc_cmd_myid",
+    "ooc_cmd_hpset",
 ]
 
 
@@ -543,3 +545,33 @@ def ooc_cmd_myid(client, arg):
     if client.name != "":
         info += f": {client.name}"
     client.send_ooc(info)
+
+
+@mod_only()
+def ooc_cmd_hpset(client, arg):
+    """
+    Set hp.
+    Usage: /hpset <pos> <amount> [area]
+    """
+    args = list(arg.split(" "))
+    if len(args) == 0:
+        raise ArgumentError(
+            "You must specify a position and HP. Use /hpset <pos> <amount> [area]")
+    elif len(args) == 1:
+        raise ArgumentError(
+            "You must specify HP. Use /hpset <pos> <amount> [area]")
+
+    if args[0] == "def":
+        side = 1
+    elif args[0] == "pro":
+        side = 2
+    else:
+        ArgumentError("Invalid position. Use \"pro\" or \"def\"")
+
+    if len(args) == 2:
+        for area in client.area.area_manager.areas:
+            area.change_hp(side, int(args[1]))
+    else:
+        for aid in args[2:]:
+            area = client.area.area_manager.get_area_by_id(int(aid))
+            area.change_hp(side, int(args[1]))

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -3,7 +3,6 @@ import shlex
 import arrow
 import pytimeparse
 
-
 from server import database
 from server.constants import TargetType
 from server.exceptions import ClientError, ServerError, ArgumentError

--- a/server/commands/hubs.py
+++ b/server/commands/hubs.py
@@ -44,6 +44,7 @@ __all__ = [
     "ooc_cmd_ungm",
     "ooc_cmd_broadcast",
     "ooc_cmd_clear_broadcast",
+    "ooc_cmd_hpset",
 ]
 
 
@@ -940,3 +941,32 @@ def ooc_cmd_clear_broadcast(client, arg):
         return
     client.broadcast_list.clear()
     client.send_ooc("Your broadcast list has been cleared.")
+
+@mod_only(area_owners=True)
+def ooc_cmd_hpset(client, arg):
+    """
+    Set hp.
+    Usage: /hpset <pos> <amount> [area]
+    """
+    args = list(arg.split(" "))
+    if len(args) == 0:
+        raise ArgumentError(
+            "You must specify a position and HP. Use /hpset <pos> <amount> [area]")
+    elif len(args) == 1:
+        raise ArgumentError(
+            "You must specify HP. Use /hpset <pos> <amount> [area]")
+
+    if args[0] == "def":
+        side = 1
+    elif args[0] == "pro":
+        side = 2
+    else:
+        ArgumentError("Invalid position. Use \"pro\" or \"def\"")
+
+    if len(args) == 2:
+        for area in client.area.area_manager.areas:
+            area.change_hp(side, int(args[1]))
+    else:
+        for aid in args[2:]:
+            area = client.area.area_manager.get_area_by_id(int(aid))
+            area.change_hp(side, int(args[1]))


### PR DESCRIPTION
A command to change the hp of area(s). If no optional area argument is provided, will change all areas.
Otherwise, changes all space-separated areas provided after the HP  

Example: `/hpset def 5 0 1 2 3` sets HP 5 to areas 0, 1, 2, 3 for def position.