### PR TITLE
No more blankpost spam

### DIFF
--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -824,7 +824,6 @@ class AOProtocol(asyncio.Protocol):
             self.server.config["block_repeat"]
             and not self.client.is_mod
             and not (self.client in self.client.area.owners)
-            and text.strip() != ""
             and self.client.area.last_ic_message is not None
             and cid == self.client.area.last_ic_message[8]
             and text == self.client.area.last_ic_message[4]

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -826,7 +826,7 @@ class AOProtocol(asyncio.Protocol):
             and not (self.client in self.client.area.owners)
             and self.client.area.last_ic_message is not None
             and cid == self.client.area.last_ic_message[8]
-            and text == self.client.area.last_ic_message[4]
+            and (text == self.client.area.last_ic_message[4] or text.strip() == self.client.area.last_ic_message[4])
         ):
             self.client.send_ooc(
                 "Your message is a repeat of the last one, don't spam!"


### PR DESCRIPTION
Blankposts could bypass the repeat filter, giving spammers the opportunity to just spam like 10 blankposts a second and lagging slow clients.