### PR TITLE
Fix delay being 0 for blankpost and log OOC commands

### DIFF
--- a/server/area.py
+++ b/server/area.py
@@ -1303,7 +1303,7 @@ class Area:
         for char in "@$`|_~%\\}{":
             msg = msg.replace(char, "")
         # Very basic approximation of text length
-        delay = len(msg) * 40
+        delay = len(msg) * 40 + 40
         # Minimum area msg delay
         delay = max(self.min_msg_delay, delay)
         # Maximum area msg delay

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -1321,6 +1321,8 @@ class AOProtocol(asyncio.Protocol):
                 "Your message was not sent for safety reasons: you left space before that slash."
             )
             return
+        database.log_area("chat.ooc", self.client,
+                          self.client.area, message=args[1])
         if args[1].startswith("/"):
             spl = args[1][1:].split(" ", 1)
             cmd = spl[0].lower()
@@ -1365,8 +1367,6 @@ class AOProtocol(asyncio.Protocol):
         self.client.area.send_owner_command(
             "CT", f"[{self.client.area.id}]{name}", args[1]
         )
-        database.log_area("chat.ooc", self.client,
-                          self.client.area, message=args[1])
 
     def net_cmd_mc(self, args):
         """Play music.


### PR DESCRIPTION
the message delay could be bypassed with blankposts because of a division by zero resulting in 0 because we discard all exceptions

and this logs ooc commands like other messages too so you can figure out how the next amazing exploit works