### PR TITLE
Perma ban info access fix

### DIFF
--- a/server/database.py
+++ b/server/database.py
@@ -288,7 +288,8 @@ class Database:
 
         def __post_init__(self):
             self.ban_date = arrow.get(self.ban_date).datetime
-            self.unban_date = arrow.get(self.unban_date).datetime
+            if self.unban_date is not None:
+                self.unban_date = arrow.get(self.unban_date).datetime
 
         @property
         def ipids(self):

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -201,7 +201,10 @@ class AOProtocol(asyncio.Protocol):
 
             msg = f"{ban.reason}\r\n"
             msg += f"ID: {ban.ban_id}\r\n"
-            msg += f"Until: {unban_date.humanize()}"
+            if unban_date == "N/A":
+                msg += f"Until: {unban_date}"
+            else:
+                msg += f"Until: {unban_date.humanize()}"
 
             database.log_connect(self.client, failed=True)
             self.client.send_command("BD", msg)


### PR DESCRIPTION
"Perma" bans cause the server to throw up an error when a permanently banned user attempts to connect because it can't date/time parse "None" for the pop-up.
A quick check prevents this, showing the intended "N/A" instead of trying to format.

Also addresses issue #89 by showing "N/A" as the unban date in `/baninfo`, preventing errors in `/bans` and `/baninfo #`.