### PR TITLE
[Master-server] Handle the missing error cases 

### DIFF
--- a/server/network/masterserverclient.py
+++ b/server/network/masterserverclient.py
@@ -46,7 +46,10 @@ class MasterServerClient:
                 try:
                     await self.send_server_info(http)
                 except aiohttp.ClientError:
-                    logger.exception('Connection error occurred.')
+                    logger.exception('Connection error occurred. (Master server down?)')
+                except: # If is a unknown error
+                    logger.debug("Connection error occurred. (No internet?)")
+                    await asyncio.sleep(5)
                 finally:
                     await asyncio.sleep(60)
 


### PR DESCRIPTION
It fixes a bug where the server would randomly disappear from the master-list without even knowing why.
That issue was caused by a missing error handling for the case where the hosting server didn't have an internet connection after the sleep period of 60 seconds.

Additionally, the error printing got updated to provide more detailed information.