### PR TITLE
Add advertising for secure websocket

### DIFF
--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -45,8 +45,8 @@ use_websockets: true
 websocket_port: 50001
 
 # This setting is only used for advertising the server on the server list
-# and is not used for actual connections, since typically a secure connection
-# should be terminated at a reverse proxy.
+# and is not used for actual connections, since a secure connection
+# should typically be terminated at a reverse proxy.
 use_securewebsockets: false
 securewebsocket_port: 50002
 

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -44,7 +44,10 @@ motd: Welcome to my server!
 use_websockets: true
 websocket_port: 50001
 
-use_securewebsockets: true
+# This setting is only used for advertising the server on the server list
+# and is not used for actual connections, since typically a secure connection
+# should be terminated at a reverse proxy.
+use_securewebsockets: false
 securewebsocket_port: 50002
 
 # WebAO Asset URL for hosting files. Leave blank to use vanilla

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -43,6 +43,10 @@ motd: Welcome to my server!
 # and must also be forwarded.
 use_websockets: true
 websocket_port: 50001
+
+use_securewebsockets: true
+securewebsocket_port: 50002
+
 # WebAO Asset URL for hosting files. Leave blank to use vanilla
 asset_url:
 

--- a/server/network/masterserverclient.py
+++ b/server/network/masterserverclient.py
@@ -34,6 +34,7 @@ stun_servers = [
 
 API_BASE_URL = 'https://servers.aceattorneyonline.com'
 
+
 class MasterServerClient:
     """Advertises information about this server to the master server."""
 
@@ -46,8 +47,9 @@ class MasterServerClient:
                 try:
                     await self.send_server_info(http)
                 except aiohttp.ClientError:
-                    logger.exception('Connection error occurred. (Master server down?)')
-                except: # If is a unknown error
+                    logger.exception(
+                        'Connection error occurred. (Master server down?)')
+                except:  # If is a unknown error
                     logger.debug("Connection error occurred. (No internet?)")
                     await asyncio.sleep(5)
                 finally:
@@ -83,6 +85,7 @@ class MasterServerClient:
             try:
                 res.raise_for_status()
             except aiohttp.ClientResponseError as err:
-                logging.error(f"Got status={err.status} advertising {body}: {err_body}")
+                logging.error(
+                    f"Got status={err.status} advertising {body}: {err_body}")
 
         logger.debug(f'Heartbeat to {API_BASE_URL}/servers')

--- a/server/network/masterserverclient.py
+++ b/server/network/masterserverclient.py
@@ -66,7 +66,6 @@ class MasterServerClient:
         loop = asyncio.get_event_loop()
         cfg = self.server.config
         body = {
-            'ip': await loop.run_in_executor(None, self.get_my_ip),
             'port': cfg['port'],
             'name': cfg['masterserver_name'],
             'description': cfg['masterserver_description'],
@@ -75,6 +74,9 @@ class MasterServerClient:
 
         if 'masterserver_custom_hostname' in cfg:
             body['ip'] = cfg['masterserver_custom_hostname']
+        else:
+            body['ip'] = await loop.run_in_executor(None, self.get_my_ip)
+
         if cfg['use_websockets']:
             body['ws_port'] = cfg['websocket_port']
         if cfg['use_securewebsockets']:

--- a/server/network/masterserverclient.py
+++ b/server/network/masterserverclient.py
@@ -75,6 +75,8 @@ class MasterServerClient:
             body['ip'] = cfg['masterserver_custom_hostname']
         if cfg['use_websockets']:
             body['ws_port'] = cfg['websocket_port']
+        if cfg['use_securewebsockets']:
+            body['wss_port'] = cfg['securewebsocket_port']
 
         async with http.post(f'{API_BASE_URL}/servers', json=body) as res:
             err_body = await res.text()


### PR DESCRIPTION
Add advertising secure websocket to MS, so it can advertise that the server can accept encrypted connections(wss), which are also preferable from a security and privacy point of view. As the application server, it should in principle not be burdened with decryption and managing certificates. It is better to configure this on either a reverse proxy (eg. nginx) or do it through cloudflare. It would be best to create additional documentation on how to set this up correctly.

I'm assuming that for most "small" servers setting this up isn't a realistic option, but it could make sense for the bigger servers.

This will also require a (hopefully small) change in MS too (adding wss_port field), so looping in @oldmud0