### PR TITLE
Initial AOG 1.0 RC1 release

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -180,6 +180,9 @@ class ClientManager:
             # Currently requested subtheme of this client
             self.subtheme = ""
 
+            # The last char_url set by this client.
+            self.char_url = ""
+
             # Compatibility stuff
             # Determine if this client can support multi-layered audio (such as ambience)
             self.has_multilayer_audio = False
@@ -1046,6 +1049,9 @@ class ClientManager:
                         c.send_ooc(ex)
                         c.unfollow()
                         return
+            # Last error check got done above.
+
+            self.clear_area_char_links(old_area)
 
             reason = ""
             if (
@@ -1162,6 +1168,50 @@ class ClientManager:
                 self.send_ooc(
                     "This area is muted - you cannot talk in-character unless invited."
                 )
+
+        # User links stuff
+        def remove_user_link(self, char_name):
+            """Removes an user link on this client."""
+            self.send_command("CU", "0", "0", char_name)
+
+        def add_user_link(self, char_name, char_url):
+            """Adds an user link on this client."""
+            self.send_command("CU", "0", "1", char_name, char_url)
+
+        def clear_user_links(self):
+            """Clear all user links of this client."""
+            self.send_command("CU", "0", "2")
+
+        def get_new_area_user_links(self):
+            """"
+            Get the char_urls of the new area that the client changed to.
+            And applying the changes.
+            """
+
+            self.clear_user_links()
+
+            clients = (c for c in self.area.clients if c.id != self.id)
+
+            for client in clients:
+                self.add_user_link(client.char_name, client.char_url)
+
+
+
+        def clear_area_char_links(self, old_area):
+            """
+            Clears all user links in the old area.
+            And declare them in the new area.
+            The client should be already in the new area for this to be called
+            """
+            self.get_new_area_user_links()
+
+            for client in old_area.clients:
+                client.remove_user_link(self.char_name)
+            clients = (c for c in self.area.clients if c.id != self.id)
+
+            for client in clients:
+                client.add_user_link(self.char_name, self.char_url)
+
 
         def get_area_list(self, hidden=False, unlinked=False):
             area_list = []


### PR DESCRIPTION
### Changelog
- Adds the /overlay ooc command with a "overlay_lock" option, working the same as "bg_lock". 
- Implements the extended BN (background change) packet from AOG 1.0

**Manages the new CU packet of AOG 1.0**
Added a new variable of "client.char_url" used to store the URL of the character the person is using, so everyone else can download it more easily without needing to share the URL every single time manually.

The CU packet is sended everytime the client changes their character.
The client is expected  to send their CU packets on the  "user authority level".

The server can declare their URLs too with the "server authority level".
They are global URLs compared to the user's ones that are per-area

AOG 1.0 client implementation:

The URL on the client is loaded from a "Download.ini" located on every character folder.
They can opt to automatically share their URLs or to either share them manually with a button.



**Manages the new TT packet of AOG 1.0**
 Sended when the client is typing on the IC chat.
See more details on the implementation.
 
 
 In collaboration with @Satoru-1816