### PR TITLE
Use bash for unix-start

### DIFF
--- a/start-unix.sh
+++ b/start-unix.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euxo pipefail
 


### PR DESCRIPTION
the options on line 3 aren't valid for normal sh, so it may fail on some systems