### PR TITLE
Add the ability to use the DL Manager functionality outside of AOG

### DIFF
--- a/config_sample/command_aliases.yaml
+++ b/config_sample/command_aliases.yaml
@@ -101,3 +101,9 @@ swaptestimony: testimony_swap
 unlistenpos: unlisten_pos
 unmuteooc: ooc_unmute
 aga: autogetarea
+gl: getlink
+gls: getlinks
+seturl: set_url
+surl: set_url
+get_link: getlink
+get_links: getlinks

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -1356,7 +1356,7 @@ class ClientManager:
             info += f"[{area.id}] {area.name}{users}{status}{owner}{hidden}{locked}{pathlocked}{passworded}{muted}{dark}"
             return info
 
-        def get_area_clients(self, area_id, mods=False, afk_check=False):
+        def get_area_clients(self, area_id, mods=False, afk_check=False, show_links=False):
             info = ""
             area = self.area.area_manager.get_area_by_id(area_id)
             if afk_check:
@@ -1428,9 +1428,11 @@ class ClientManager:
                     info += f" ({c.ipid})"
                 if c.name != "" and (self.is_mod or self in area.owners):
                     info += f": {c.name}"
+                if show_links and c.char_url != "":
+                    info += f" < {c.char_url} >"
             return info
 
-        def send_areas_clients(self, mods=False, afk_check=False):
+        def send_areas_clients(self, mods=False, afk_check=False, show_links=False):
             """
             Send information over OOC about all areas of the client's hub.
             :param area_id: area ID
@@ -1465,7 +1467,7 @@ class ClientManager:
                     continue
 
                 try:
-                    area_info += self.get_area_clients(i, mods, afk_check)
+                    area_info += self.get_area_clients(i, mods, afk_check, show_links)
                 except ClientError:
                     area_info = ""
                 if area_info == "":
@@ -1483,7 +1485,7 @@ class ClientManager:
                 info += f"Current online: {cnt}"
             self.send_ooc(info)
 
-        def send_area_info(self, area_id, mods=False, afk_check=False):
+        def send_area_info(self, area_id, mods=False, afk_check=False, show_links=False):
             """
             Send information over OOC about a specific area.
             :param area_id: area ID
@@ -1496,7 +1498,7 @@ class ClientManager:
                     raise ClientError("You are blinded!")
             area_info = f'📍 Clients in {self.get_area_info(area_id)} 📍'
             try:
-                area_info += self.get_area_clients(area_id, mods, afk_check)
+                area_info += self.get_area_clients(area_id, mods, afk_check, show_links)
             except ClientError as ex:
                 area_info += f'\n{ex}'
             info += area_info

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -16,6 +16,8 @@ __all__ = [
     "ooc_cmd_autogetarea",
     "ooc_cmd_getarea",
     "ooc_cmd_getareas",
+    "ooc_cmd_getlinks",
+    "ooc_cmd_getlink",
     "ooc_cmd_getafk",
     "ooc_cmd_invite",
     "ooc_cmd_uninvite",
@@ -224,6 +226,30 @@ def ooc_cmd_getareas(client, arg):
     """
     client.send_areas_clients()
 
+def ooc_cmd_getlink(client, arg):
+    """
+    Show information about the current area, or target area id with sufficient permissions.
+    Including the client's link.
+    Usage: /getlink [id]
+    """
+    aid = client.area.id
+    if arg.strip().isnumeric():
+        area = client.area.area_manager.get_area_by_id(int(arg))
+        if area.id == client.area.id or (client.is_mod or client in area.owners):
+            aid = int(arg)
+        else:
+            raise ClientError(
+                "Can't see that area - insufficient permissions!")
+    client.send_area_info(aid, show_links=True)
+
+
+def ooc_cmd_getlinks(client, arg):
+    """
+    Show information about all areas.
+    Including the client's link.
+    Usage: /getlinks
+    """
+    client.send_areas_clients(show_links=True)
 
 def ooc_cmd_getafk(client, arg):
     """

--- a/server/commands/character.py
+++ b/server/commands/character.py
@@ -49,9 +49,36 @@ __all__ = [
     "ooc_cmd_showname",
     "ooc_cmd_charlists",
     "ooc_cmd_charlist",
-    "ooc_cmd_webfiles"
+    "ooc_cmd_webfiles",
+    "ooc_cmd_set_url",
+    "ooc_cmd_get_urls",
 ]
 
+
+def ooc_cmd_set_url(client, arg):
+    """
+    This command sets the URL of the current character.
+    That URL is used client-side on AOG and server-side with the /get_link and /get_links commands.
+    Usage: /set_url <url>
+    """
+
+    arg_strip = arg.strip()
+
+    if arg_strip == "":
+        client.send_ooc("URL has been reset successfully.")
+    else:
+        client.send_ooc(f"URL set to {arg_strip}")
+    client.char_url = arg_strip
+
+def ooc_cmd_get_urls(client, arg):
+    """
+    This command returns the server's URL List.
+    Usage: /get_urls
+    """
+    f_server_links = "Server URLs:\n"
+    for name, url in client.server.server_links.items():
+        f_server_links += f"{name}: {url} \n"
+    client.send_ooc(f_server_links)
 
 def ooc_cmd_switch(client, arg):
     """


### PR DESCRIPTION
Continuation of #100 and #102 

### Quote:
> ~Nothing sets char_url yet right? I suppose a simple command to do so should be added later on?~ Ahh the char_url is set by AOG client, I see. Commands could be added so the system can still be used on pre-AOG clients in a different PR

## Things to note:
I put a " " after each link, because AO2 would think that "\n" doesn't break the hyper-link markdown, while " " does.
An issue should be made for it.

## Changes
- Add the /getlink and /getlinks commands. They work exactly like /getarea and /getareas, but it includes the client link at the end of each.
- Add /get_urls, that gives all the server-side URLs declared on server_links.yaml in the same syntax (doesn't include comments tho)
- Gave every new command added (getlink, getlinks, get_urls) shortcuts on the command_aliases.yaml file.