### PR TITLE
/pm now works if target is in a different hub

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -1933,7 +1933,7 @@ class ClientManager:
                     ],
                 )
 
-    def get_targets(self, client, key, value, local=False, single=False):
+    def get_targets(self, client, key, value, local=False, single=False, all_hub=False):
         """
         Find players by a combination of identifying data.
         Possible keys: player ID, OOC name, character name, HDID, IPID,
@@ -1944,36 +1944,41 @@ class ClientManager:
         :param value: data identifying a client
         :param local: search in current area only (Default value = False)
         :param single: search only a single user (Default value = False)
+        :param all_hub: search in all hubs (Default = False)
         """
-        areas = None
-        if local:
-            areas = [client.area]
-        else:
-            areas = client.area.area_manager.areas
         targets = []
         if key == TargetType.ALL:
             for nkey in range(6):
                 targets += self.get_targets(client, nkey, value, local)
-        for area in areas:
-            for client in area.clients:
-                if key == TargetType.IP:
-                    if value.lower().startswith(client.ip.lower()):
-                        targets.append(client)
-                elif key == TargetType.OOC_NAME:
-                    if value.lower().startswith(client.name.lower()) and client.name:
-                        targets.append(client)
-                elif key == TargetType.CHAR_NAME:
-                    if value.lower().startswith(client.char_name.lower()):
-                        targets.append(client)
-                elif key == TargetType.ID:
-                    if client.id == value:
-                        targets.append(client)
-                elif key == TargetType.IPID:
-                    if client.ipid == value:
-                        targets.append(client)
-                elif key == TargetType.AFK:
-                    if client in area.afkers:
-                        targets.append(client)
+        if all_hub and not local:
+            hubs = self.server.hub_manager.hubs
+        else:
+            hubs = [client.area.area_manager]
+        for hub in hubs:
+            if local:
+                areas = [client.area]
+            else:
+                areas = hub.areas
+            for area in areas:
+                for client in area.clients:
+                    if key == TargetType.IP:
+                        if value.lower().startswith(client.ip.lower()):
+                            targets.append(client)
+                    elif key == TargetType.OOC_NAME:
+                        if value.lower().startswith(client.name.lower()) and client.name:
+                            targets.append(client)
+                    elif key == TargetType.CHAR_NAME:
+                        if value.lower().startswith(client.char_name.lower()):
+                            targets.append(client)
+                    elif key == TargetType.ID:
+                        if client.id == value:
+                             targets.append(client)
+                    elif key == TargetType.IPID:
+                        if client.ipid == value:
+                            targets.append(client)
+                    elif key == TargetType.AFK:
+                        if client in area.afkers:
+                            targets.append(client)
         return targets
 
     def get_muted_clients(self):

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -1944,7 +1944,7 @@ class ClientManager:
         :param value: data identifying a client
         :param local: search in current area only (Default value = False)
         :param single: search only a single user (Default value = False)
-        :param all_hub: search in all hubs (Default = False)
+        :param all_hub: search in all hubs (Default value = False)
         """
         targets = []
         if key == TargetType.ALL:

--- a/server/commands/messaging.py
+++ b/server/commands/messaging.py
@@ -137,6 +137,7 @@ def ooc_cmd_pm(client, arg):
     """
     Send a private message to another online user. These messages are not
     logged by the server owner.
+    The Target Types <ooc-name> and <char-name> work only if the target is in the same area.
     Usage: /pm <id|ooc-name|char-name> <message>
     """
     args = arg.split()
@@ -152,7 +153,7 @@ def ooc_cmd_pm(client, arg):
     key = TargetType.CHAR_NAME
     if len(targets) == 0 and args[0].isdigit():
         targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(args[0]), False
+            client, TargetType.ID, int(args[0]), False, False, True
         )
         key = TargetType.ID
     if len(targets) == 0:

--- a/server/commands/messaging.py
+++ b/server/commands/messaging.py
@@ -148,17 +148,17 @@ def ooc_cmd_pm(client, arg):
             'Not enough arguments. use /pm <target> <message>. Target should be ID, OOC-name or char-name. Use /getarea for getting info like "[ID] char-name".'
         )
     targets = client.server.client_manager.get_targets(
-        client, TargetType.CHAR_NAME, arg, True
+        client, TargetType.CHAR_NAME, arg, local=True
     )
     key = TargetType.CHAR_NAME
     if len(targets) == 0 and args[0].isdigit():
         targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(args[0]), False, False, True
+            client, TargetType.ID, int(args[0]), all_hub=True
         )
         key = TargetType.ID
     if len(targets) == 0:
         targets = client.server.client_manager.get_targets(
-            client, TargetType.OOC_NAME, arg, True
+            client, TargetType.OOC_NAME, arg, local=True
         )
         key = TargetType.OOC_NAME
     if len(targets) == 0:


### PR DESCRIPTION
I rewrote get_targets in client_manager, so that now it can find players also in other hubs. (Maybe in future we can also change /ban so that it can find players in a different hub)