### PR TITLE
yt-dlp implementation in /play

### DIFF
--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -108,6 +108,15 @@ max_chars: 256
 # Maximum number of characters an IC message can contain
 max_chars_ic: 256
 
+# Allows for playing YouTube URLs as music through the /play command.
+youtube_play:
+  cache_duration: 24 # Amount of hours before the URL should be removed from the cache. Set to 0 to never delete the cache entry.
+  request_url: "https://litterbox.catbox.moe/resources/internals/api.php" # Endpoint for the POST request.
+  file_form_name: fileToUpload # The endpoint's expected key for the file. 
+  args: # Additional arguments to pass in the POST request.
+    time: 24h
+    reqtype: fileupload
+
 # Set up a Discord Bridge bot that keeps track of user messages on both ends (AO2 and Discord).
 bridgebot:
   enabled: false # Whether or not this bot is enabled

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ types-python-dateutil==2.8.19.14
 urllib3==2.1.0
 websockets==12.0
 yarl==1.9.2
+yt-dlp==2023.12.30

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -361,11 +361,14 @@ class ClientManager:
 
             self.area.update_timers(self, running_only=True)
 
+        '''
         def save_yt_cache(self):
-            pass #Let's just do yaml instead of json. Python plays nicer.
+            with open("storage/yt_cache.yaml", "w", encoding="utf-8") as stream:
+                yaml.dump(self.yt_cache, stream, default_flow_style=False)
 
         def load_yt_cache(self):
             pass
+        '''
 
         def mirror_youtube(self, yt_url):
             with yt_dlp.YoutubeDL(self.ydl_opts) as ydl:

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -1,4 +1,3 @@
-
 import re
 import string
 import time
@@ -15,6 +14,7 @@ from server.constants import TargetType, encode_ao_packet, contains_URL
 from server.exceptions import ClientError, AreaError, ServerError
 
 import oyaml as yaml  # ordered yaml
+
 
 class ClientManager:
     """Holds the list of all clients currently connected to the server."""
@@ -433,7 +433,6 @@ class ClientManager:
                             raise
                 if not loop:
                     length = 0
-
 
                 if (contains_URL(song)):
                     checked = False

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -289,6 +289,17 @@ class TsuServer3:
         if "global_chat" not in self.config:
             self.config["global_chat"] = True
 
+        if "youtube_play" not in self.config:
+            self.config["youtube_play"] = {
+              "cache_duration": 24,
+              "request_url": "https://litterbox.catbox.moe/resources/internals/api.php",
+              "file_form_name": "fileToUpload",
+              "args": { 
+                   "time": "24h",
+                   "reqtype": "fileupload"
+                   }
+              }
+
     def load_command_aliases(self):
         """Load a list of alternative command names."""
         try:


### PR DESCRIPTION
/play will now download YouTube URLs and upload them to the endpoint of a user's choice, then send the resulting URL to the clients in said area to play the song, allowing for more convenient use of music from YouTube.

The `yt_cache` dictionary can be saved as a yaml for a cache which persists throughout server shutdowns as previously discussed, though I have not yet integrated such a feature.