### PR TITLE
Do not let area owners bypass ooc floodguard

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -695,7 +695,7 @@ class ClientManager:
             Check if the client can use OOC or not.
             :returns: how many seconds the client must wait to use OOC
             """
-            if self.is_mod or self in self.area.owners:
+            if self.is_mod:
                 return 0
             if self.ooc_mute_time:
                 if (


### PR DESCRIPTION
Currently, if you are the owner in the current area, you can bypass the floodguard completely, but OOC commands such as /g and /need send messages to the whole server and can easily be abused.