### PR TITLE
Fix "format_timer" instead of "timer_format"

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -522,12 +522,12 @@
     - `start` starts the previously set timer, so `/timer 0 start`.
     - `pause` OR `stop` pauses the timer that's currently running, so `/timer 0 pause`.
     - `unset` OR `hide` hides the timer for it to no longer show up, so `/timer 0 hide`.
-* **format_timer** `<id> <format>`
+* **timer\_format** `<id> <format>`
     - Format the timer in the current area or hub.
-    - Example of format: `Time Left: hh:mm`
+    - Example of format: `'Time Left:' hh:mm`
     - Default format: `hh:mm:ss.zzz`
     - For more information on how to implement your format, [go here!](https://doc.qt.io/qt-6/qtime.html#toString)
-* **timer_interval** `<id> <interval>`
+* **timer\_interval** `<id> <interval>`
     - Set timer interval in the current area or hub.
     - Example: `/timer_interval 1 15m`
     - Default interval: `/timer_interval 1 16ms`

--- a/server/area.py
+++ b/server/area.py
@@ -742,7 +742,7 @@ class Area:
             if timer.started:
                 current_time = timer.target - arrow.get()
             int_time = int(current_time.total_seconds()) * 1000
-            client.send_timer_set_time(0, int_time, timer.started)
+            client.send_timer_set_time(0, int_time, timer.started, timer.format, timer.interval)
         elif not running_only:
             client.send_timer_set_time(0, None, False)
 
@@ -754,7 +754,7 @@ class Area:
                 if timer.started:
                     current_time = timer.target - arrow.get()
                 int_time = int(current_time.total_seconds()) * 1000
-                client.send_timer_set_time(timer_id + 1, int_time, timer.started)
+                client.send_timer_set_time(timer_id + 1, int_time, timer.started, timer.format, timer.interval)
             elif not running_only:
                 client.send_timer_set_time(timer_id + 1, None, False)
 
@@ -927,10 +927,10 @@ class Area:
                 if c.area.background != bg:
                     c.send_command("BN", c.area.background)
 
-    def send_timer_set_time(self, timer_id=None, new_time=None, start=False):
+    def send_timer_set_time(self, timer_id=None, new_time=None, start=False, format=None, interval=None):
         """Broadcast a timer to all clients in this area."""
         for c in self.clients:
-            c.send_timer_set_time(timer_id, new_time, start)
+            c.send_timer_set_time(timer_id, new_time, start, format, interval)
 
     def broadcast_ooc(self, msg):
         """

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -601,10 +601,10 @@ class AreaManager:
             a.send_command(cmd, *args)
             a.send_owner_command(cmd, *args)
 
-    def send_timer_set_time(self, timer_id=None, new_time=None, start=False):
+    def send_timer_set_time(self, timer_id=None, new_time=None, start=False, format=None, interval=None):
         """Broadcast a timer to all areas in this hub."""
         for area in self.areas:
-            area.send_timer_set_time(timer_id, new_time, start)
+            area.send_timer_set_time(timer_id, new_time, start, format, interval)
 
     def broadcast_area_list(self, refresh=False):
         """Global update of all areas for the client music lists in the hub."""

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -344,11 +344,11 @@ class ClientManager:
             limit = self.server.config["playerlimit"]
             self.send_ooc(f"👥{players}/{limit} players online.")
 
-        def send_timer_set_time(self, timer_id=None, new_time=None, start=False):
+        def send_timer_set_time(self, timer_id=None, new_time=None, start=False, format=None, interval=None):
             if self.software == "DRO":
                 # configuration. There's no situation where these values are different on KFO-Server
-                self.send_timer_set_step_length(timer_id, -16) # 16 milliseconds, matches AO
-                self.send_timer_set_firing_interval(timer_id, 16) # 16 milliseconds, matches AO
+                self.send_timer_set_step_length(timer_id, -timer.interval) # 16 milliseconds, matches AO
+                self.send_timer_set_firing_interval(timer_id, timer.interval) # 16 milliseconds, matches AO
                 
                 self.send_command("TST", timer_id, new_time) # set time
                 if start:
@@ -366,19 +366,10 @@ class ClientManager:
                         timer = self.area.area_manager.timer
                     else:
                         timer = self.area.timers[timer_id-1]
-                    self.send_command("TF", timer_id, timer.format, new_time)
-                    self.send_command("TIN", timer_id, timer.interval)
-
-        def send_timer_set_interval(self, timer_id, timer):
-            if timer.started:
-                current_time = timer.target - arrow.get()
-                current_time = int(current_time.total_seconds()) * 1000
-            else:
-                current_time = int(timer.static.total_seconds()) * 1000
-            if timer_id == 0:
-                    self.area.area_manager.send_timer_set_time(timer_id, current_time, timer.started)
-            else:
-                    self.area.send_timer_set_time(timer_id, current_time, timer.started)
+                    if format:
+                        self.send_command("TF", timer_id, format, new_time)
+                    if interval:
+                        self.send_command("TIN", timer_id, interval)
 
         def send_timer_set_step_length(self, timer_id=None, new_step_length=None):
             if self.software == "DRO":
@@ -390,7 +381,7 @@ class ClientManager:
             if self.software == "DRO":
                 self.send_command("TSF", timer_id, new_firing_interval) #set firing
             else:
-                pass # no ao equivalent
+                self.send_command("TIN", timer_id, new_firing_interval)
 
         def is_valid_name(self, name):
             """


### PR DESCRIPTION
Fix timer format and intervals not being properly set or updated
Improve timer_format documentation to be more descriptive

TODO:
* Fix larger intervals setting the timer to 0 at some steps for some reason
* Fix send_timer_set_step_length not having an AO equivalent. Should work practically the same, allowing the user to create timers ticking _up_.