### PR TITLE
Introduce discord whitelisting for authentication

### DIFF
--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -130,8 +130,11 @@ bridgebot:
   announce_ping: false
   announce_role:
 
-# REQUIRES BRIDGEBOT to be enabled and WEBHOOKS for whitelist request to be sent
+# REQUIRES BRIDGEBOT to be enabled and optional webhook url for whitelist request to be sent/separate from other webhooks
 whitelist: false
+# enable if you want webhook logging of whitelist requests
+wl_request_hook: false
+wl_webhook_url: # set webhook for discord whitelist channel here
 
 # Whether or not Discord webhooks are enabled, and if they are, the webhook URL to use.
 # If webhooks_enabled is set to false, no webhooks will function regardless of whether they are enabled or not.

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -130,6 +130,9 @@ bridgebot:
   announce_ping: false
   announce_role:
 
+# REQUIRES BRIDGEBOT to be enabled and WEBHOOKS for whitelist request to be sent
+whitelist: false
+
 # Whether or not Discord webhooks are enabled, and if they are, the webhook URL to use.
 # If webhooks_enabled is set to false, no webhooks will function regardless of whether they are enabled or not.
 webhooks_enabled: false

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -79,6 +79,11 @@ class ClientManager:
             self.casing_steno = False
             self.case_call_time = 0
 
+            # whitelist related
+            self.discord_name = ''
+            self.is_wlisted = False
+            self.player_id = -1
+
             # Need command
             self.need_call_time = 0
 

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -1564,6 +1564,8 @@ class ClientManager:
                     info += f'"{c.showname}" ({c.char_name})'
                 else:
                     info += f"{c.showname}"
+                if c.is_wlisted and c.server.config["whitelist"]:
+                    info += f' [Disc: {c.discord_name}]'
                 if c.pos != "":
                     info += f" <{c.pos}>"
                 if self.is_mod:

--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -6,6 +6,8 @@ import pytimeparse
 from server import database
 from server.constants import TargetType
 from server.exceptions import ClientError, ServerError, ArgumentError
+from random import randrange
+import threading
 import asyncio
 
 from . import mod_only, list_commands, list_submodules, help
@@ -13,6 +15,7 @@ from . import mod_only, list_commands, list_submodules, help
 __all__ = [
     "ooc_cmd_motd",
     "ooc_cmd_help",
+    "ooc_cmd_whitelist",
     "ooc_cmd_kick",
     "ooc_cmd_ban",
     "ooc_cmd_banhdid",
@@ -87,6 +90,24 @@ def ooc_cmd_help(client, arg):
                     f"No such command or submodule ({arg}) has been found in the help docs."
                 )
 
+def ooc_cmd_whitelist(client, arg):
+	"""
+	Send a request to activate whitelist
+	Usage: /whitelist <name>
+	"""
+	if not (client.server.config["whitelist"]):
+		raise ArgumentError("Whitelist is not enabled on this server!")
+	if client.is_wlisted == True:
+		raise ArgumentError("You have already been whitelisted!")
+	if len(arg) == 0:
+		raise ArgumentError("You must specify a discord username.")
+	disc_name = arg
+	client.discord_name = disc_name
+	get_pid = hex((randrange(1000000)) * 100)
+	client.player_id=get_pid[2:]
+	threading.Timer(randrange(5, 10), client.server.webhooks.whitelistrequest, args=(disc_name, client)).start()
+	client.send_ooc(f"Whitelist request sent! Your Player ID is {client.player_id}")
+    
 
 @mod_only()
 def ooc_cmd_kick(client, arg):

--- a/server/discordbot.py
+++ b/server/discordbot.py
@@ -67,6 +67,40 @@ class Bridgebot(commands.Bot):
                 await channel.send(embed=embed)
 
         @self.tree.command()
+        async def whitelist(interaction: discord.Interaction, pid: str):
+            if not interaction.guild:
+                await interaction.response.send_message("Command may not be sent in direct messages!")
+                return
+            if not self.server.config["whitelist"]:
+                await interaction.response.send_message("Whitelisting is disabled on the AO server.")
+            player_id = pid.strip()
+            player_name = interaction.user.name
+            if player_id == "-1":
+                await interaction.response.send_message("Something went wrong...")
+                return
+            for c in self.server.client_manager.clients:
+                if c.player_id == player_id:
+                    if c.is_wlisted == True:
+                        emb=discord.Embed(title="WHITELIST FAILURE", description=f"This user is already whitelisted, {interaction.user.name}!", color=discord.Color.red())
+                        await interaction.response.send_message(embed=emb, ephemeral=True)
+                        return
+                    if player_name != c.discord_name:
+                        emb=discord.Embed(title="WHITELIST FAILURE", description=f"The user's discord username does not match yours, {interaction.user.name}!", color=discord.Color.red())
+                        await interaction.response.send_message(embed=emb, ephemeral=True)
+                        return
+                    c.is_wlisted = True
+                    c.discord_name = player_name
+
+                    c.send_ooc(f"Whitelisted as {player_name}.")
+                    emb=discord.Embed(title="WHITELIST SUCCESS", description=f"The user with PID: {player_id} has been whitelisted, {interaction.user.name}!", color=discord.Color.green())
+                    await interaction.response.send_message(embed=emb, ephemeral=False)
+                    return
+                    
+            emb=discord.Embed(title="WHITELIST FAILURE", description=f"A client with that Player ID cannot be found, {interaction.user.name}!", color=discord.Color.red())
+            await interaction.response.send_message(embed=emb, ephemeral=False)
+            return
+
+        @self.tree.command()
         async def gethubs(interaction: discord.Interaction):
             msg = ""
             number_players = int(self.server.player_count)

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -360,6 +360,9 @@ class AOProtocol(asyncio.Protocol):
         if self.client.is_muted:  # Checks to see if the client has been muted by a mod
             self.client.send_ooc("You are muted by a moderator.")
             return
+        if self.client.server.config["whitelist"] and not self.client.is_wlisted:
+            self.client.send_ooc('You must be whitelisted from discord!')
+            return
 
         showname = ""
         charid_pair = -1
@@ -1580,6 +1583,12 @@ class AOProtocol(asyncio.Protocol):
 
         if not self.client.is_checked:
             return
+        if self.client.server.config["whitelist"] and not self.client.is_wlisted:
+            if args[1].startswith('/whitelist'):
+                pass
+            else:
+                self.client.send_ooc('You must be whitelisted from discord!')
+                return
         if (
             self.client.is_ooc_muted
         ):  # Checks to see if the client has been muted by a mod
@@ -1718,7 +1727,11 @@ class AOProtocol(asyncio.Protocol):
         """
         if not self.client.is_checked:
             return
-        
+
+        if self.client.server.config["whitelist"] and not self.client.is_wlisted:
+            self.client.send_ooc('You must be whitelisted from discord!')
+            return
+
         if len(args) <= 0:
             return
 
@@ -1790,6 +1803,9 @@ class AOProtocol(asyncio.Protocol):
 
         """
         if not self.client.is_checked:
+            return
+        if self.client.server.config["whitelist"] and not self.client.is_wlisted:
+            self.client.send_ooc('You must be whitelisted from discord!')
             return
         if self.client.is_muted:  # Checks to see if the client has been muted by a mod
             self.client.send_ooc("You are muted by a moderator.")
@@ -2018,6 +2034,9 @@ class AOProtocol(asyncio.Protocol):
         """
         if not self.client.is_checked:
             return
+        if self.client.server.config["whitelist"] and not self.client.is_wlisted:
+            self.client.send_ooc('You must be whitelisted from discord!')
+            return
         if not self.validate_net_cmd(
             args,
             self.ArgType.STR_OR_EMPTY,
@@ -2042,6 +2061,9 @@ class AOProtocol(asyncio.Protocol):
         """
         if not self.client.is_checked:
             return
+        if self.client.server.config["whitelist"] and not self.client.is_wlisted:
+            self.client.send_ooc('You must be whitelisted from discord!')
+            return
         if not self.validate_net_cmd(args, self.ArgType.INT):
             return
         self.client.area.evi_list.del_evidence(self.client, int(args[0]))
@@ -2055,6 +2077,9 @@ class AOProtocol(asyncio.Protocol):
 
         """
         if not self.client.is_checked:
+            return
+        if self.client.server.config["whitelist"] and not self.client.is_wlisted:
+            self.client.send_ooc('You must be whitelisted from discord!')
             return
         if not self.validate_net_cmd(
             args,
@@ -2076,6 +2101,10 @@ class AOProtocol(asyncio.Protocol):
     def net_cmd_zz(self, args):
         """Sent on mod call."""
         if not self.client.is_checked:
+            return
+
+        if self.client.server.config["whitelist"] and not self.client.is_wlisted:
+            self.client.send_ooc('You must be whitelisted from discord!')
             return
 
         if self.client.is_muted:  # Checks to see if the client has been muted by a mod

--- a/server/network/webhooks.py
+++ b/server/network/webhooks.py
@@ -58,6 +58,33 @@ class Webhooks:
                 ),
             )
 
+    def send_webhook_wl(self, username=None, avatar_url=None, message=None, embed=False, title=None, description=None):
+		is_enabled = self.server.config['wl_request_hook']
+		url = self.server.config['wl_webhook_url']
+
+		if not is_enabled:
+			return
+		
+		data = {}
+		data["content"] = message
+		data["username"] = username if username is not None else "tsuserver webhook"
+		if embed == True:
+			data["embeds"] = []
+			embed = {}
+			embed["description"] = description
+			embed["title"] = title
+			data["embeds"].append(embed)
+		result = requests.post(url, data=json.dumps(data), headers={"Content-Type": "application/json"})
+		try:
+			result.raise_for_status()
+        # Passing because sending this webhook will add a delay to prevent request spams
+		except requests.exceptions.HTTPError as err:
+			pass
+			# database.log_misc('webhook.err', data=err)
+		else:
+			pass
+			# database.log_misc('webhook.ok', data="successfully delivered payload, code {}".format(result.status_code))
+
     def modcall(self, char, ipid, area, reason=None):
         is_enabled = self.server.config["modcall_webhook"]["enabled"]
         username = self.server.config["modcall_webhook"]["username"]
@@ -90,6 +117,13 @@ class Webhooks:
             title="Modcall",
             description=description,
         )
+        
+    def whitelistrequest(self, username, client=None):
+		avatar_url = self.server.config["modcall_webhook"]["avatar_url"]
+        # If client leaves server before sending webhook, it does not send to the discord
+		if(client not in self.server.client_manager.clients):
+			return
+		self.send_webhook_wl(username="Whitelist Request", avatar_url=avatar_url, message="", embed=True, title="A whitelist request has been received!", description=f"{client.char_name} (Player ID: {client.player_id}) has requested a whitelist.")
 
     def login(self, client=None, loginprofile=""):
         if "login_webhook" not in self.server.config:


### PR DESCRIPTION
A semi-complete implementation that allows server owners to require users to identify themselves through discord. This is an effective anti-raid measure in practice but would need to be further iterated on to perfect it.

I would advise testing this before considering any merge as the code comes from other tsuserver builds.