### PR TITLE
Add /bg_suffix CM-only command which allows you to set the background's suffix. The logic is it's `background + suffix` to construct the actual background path

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -958,11 +958,7 @@ class ClientManager:
             self.send_command("HP", 2, self.area.hp_pro)
 
             # Send the background information
-            if self.area.dark:
-                # TODO: separate dark area overlays
-                self.send_command("BN", self.area.background_dark, self.pos, self.area.overlay, 1)
-            else:
-                self.send_command("BN", self.area.background, self.pos, self.area.overlay, 1)
+            self.send_command("BN", self.area.background, self.pos, self.area.overlay, 1)
 
             if len(self.area.pos_lock) > 0:
                 # set that juicy pos dropdown
@@ -1735,11 +1731,7 @@ class ClientManager:
             self.send_command("CharsCheck", *self.get_available_char_list())
             self.send_command("HP", 1, self.area.hp_def)
             self.send_command("HP", 2, self.area.hp_pro)
-            if self.area.dark:
-                self.send_command(
-                    "BN", self.area.background_dark, self.area.pos_dark, self.area.overlay, 1)
-            else:
-                self.send_command("BN", self.area.background, self.pos, self.area.overlay, 1)
+            self.send_command("BN", self.area.background, self.pos, self.area.overlay, 1)
             self.send_command("LE", *self.area.get_evidence_list(self))
             self.send_command("MM", 1)
 


### PR DESCRIPTION
One example where this would be useful is if your background has 2 day/night states, and 2 states of destruction, e.g. 'intact' and 'broken'.
So you'd set it up as:
```
HotelLobby/intact/wit.png
HotelLobby/broken/wit.png

HotelLobby/Night/intact/wit.png
HotelLobby/Night/broken/wit.png
```


Then, you'd set it up as `/bg HotelLobby`, `/bg_suffix /intact`.
For night version, all you'd have to do is `/bg HotelLobby/Night` and it would preserve the suffix.
And now, if you run `/bg_suffix /broken`, it will update properly even in the Night version of the background.