### PR TITLE
remove duplicate can_gethubs in sample config

### DIFF
--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -100,9 +100,6 @@ ooc_floodguard:
   interval_length: 5
   mute_length: 30
 
-# Enables to use the command /gethubs
-can_gethubs: true
-
 # How many subscripts zalgo is stripped by; 3 is recommended as not to hurt special language diacritics
 zalgo_tolerance: 3
 


### PR DESCRIPTION
Already exists on line 82