### PR TITLE
Remove (( restriction in IC

### DIFF
--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -775,11 +775,6 @@ class AOProtocol(asyncio.Protocol):
                     )
                     return
 
-        if text.replace(" ", "").startswith("(("):
-            self.client.send_ooc(
-                "Please, *please* use the OOC chat instead of polluting IC. Normal OOC is local to area. You can use /h to talk across the hub, or /g to talk across the entire server."
-            )
-            return
         # Scrub text and showname for bad words
         if (
             self.client.area.area_manager.censor_ic


### PR DESCRIPTION
Seems incredibly opinionated to outright block this particular string just because it's commonly used for OOC messages. If it's important it could be made configurable.