### PR TITLE
2.11 Player support to support modern AO2 clients and /pm improvement

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -584,8 +584,8 @@
     - Broadcast a need for a specific role in a case.
 * **toggleadverts** `[on/off]`
     - Mute advertisements.
-* **pm** `<id|ooc-name|char-name> <message>`
-    - Send a private message to another online user. These messages are not logged by the server owner.
+* **pm** `<id[,id,id]|ooc-name|char-name> <message>`
+    - Send a private message to one or more online users. These messages are not logged by the server owner.
 * **mutepm**
     - Mute private messages.
 ## Music

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -670,29 +670,23 @@ class AreaManager:
         """Broadcast ARUP packet containing player counts."""
         if not self.arup_enabled:
             return
-        players_list = [0]
-        if len(self.server.hub_manager.hubs) > 1:
-            players_list = [0, -1]
         if clients is None:
             clients = self.clients
+        multiple_hubs = len(self.server.hub_manager.hubs) > 1
         for client in clients:
+            players_list = [0]
+            if multiple_hubs:
+                players_list.append(-1)
+            playerhubcount = 0
             for area in client.local_area_list:
                 playercount = -1
                 if not self.hide_clients and not area.hide_clients:
                     playercount = len(
                         [c for c in area.clients if not c.hidden])
+                    playerhubcount = playerhubcount + playercount
                 players_list.append(playercount)
-                playerhubcount = 0
-                for area in client.local_area_list:
-                    for c in area.clients:
-                        if (
-                            not self.hide_clients
-                            and not area.hide_clients
-                            and not c.hidden
-                        ):
-                            playerhubcount = playerhubcount + 1
-                if len(self.server.hub_manager.hubs) > 1:
-                    players_list[1] = playerhubcount
+            if multiple_hubs and len(client.local_area_list) > 0:
+                players_list[1] = playerhubcount
             self.server.send_arup(client, players_list)
 
     def send_arup_status(self, clients=None):

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -53,6 +53,7 @@ class ClientManager:
             self.software = ""
 
             self.first_joined = True
+            self.joined = False
 
             # Pairing character ID
             self.charid_pair = -1

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -542,6 +542,7 @@ class ClientManager:
             #                        *self.get_available_char_list())
             if arup:
                 self.area.area_manager.send_arup_players()
+            self.server.player_state_observer.notify_character_changed(self)
             new_char = self.char_name
             database.log_area(
                 "char.change",
@@ -1060,6 +1061,12 @@ class ClientManager:
             self.area.broadcast_area_list(self)
 
             self.area.area_manager.send_arup_players()
+
+            if old_area.area_manager != self.area.area_manager:
+                self.server.player_state_observer.notify_hub_changed(
+                    self, old_area.area_manager)
+            else:
+                self.server.player_state_observer.notify_area_id_changed(self)
 
             for hub in self.server.hub_manager.hubs:
                 count = 0
@@ -2160,6 +2167,7 @@ class ClientManager:
             self._hidden = tog
             self.send_ooc(f"You are {msg} from /getarea and playercounts.")
             self.area.area_manager.send_arup_players()
+            self.server.player_state_observer.notify_visibility_changed(self)
             if not self.sneaking:
                 self.area.broadcast_player_list()
 

--- a/server/commands/character.py
+++ b/server/commands/character.py
@@ -1292,6 +1292,8 @@ def ooc_cmd_showname(client, arg):
         client.used_showname_command = False
         client.showname = ""
         client.send_ooc("Your showname is now reset.")
+        client.server.player_state_observer.notify_character_name_changed(
+            client)
         return
     # having to copy-paste code from aoprotocol is kinda poopy, need to create a set_showname def
     if len(arg) > 20:
@@ -1304,6 +1306,7 @@ def ooc_cmd_showname(client, arg):
     client.used_showname_command = True
     client.showname = arg
     client.send_ooc(f"You set your showname to '{client.showname}'.")
+    client.server.player_state_observer.notify_character_name_changed(client)
     if not client.hidden and not client.sneaking:
         client.area.broadcast_player_list()
 

--- a/server/commands/messaging.py
+++ b/server/commands/messaging.py
@@ -143,10 +143,12 @@ def ooc_cmd_toggleadverts(client, arg):
 
 def ooc_cmd_pm(client, arg):
     """
-    Send a private message to another online user. These messages are not
+    Send a private message to one or more online users. These messages are not
     logged by the server owner.
+    Passing several IDs separated by commas opens a group conversation, and
+    everyone taking part is listed on the message so they can reply to it.
     The Target Types <ooc-name> and <char-name> work only if the target is in the same area.
-    Usage: /pm <id|ooc-name|char-name> <message>
+    Usage: /pm <id[,id,id]|ooc-name|char-name> <message>
     """
     args = arg.split()
     key = ""
@@ -155,20 +157,31 @@ def ooc_cmd_pm(client, arg):
         raise ArgumentError(
             'Not enough arguments. use /pm <target> <message>. Target should be ID, OOC-name or char-name. Use /getarea for getting info like "[ID] char-name".'
         )
-    targets = client.server.client_manager.get_targets(
-        client, TargetType.CHAR_NAME, arg, local=True
-    )
-    key = TargetType.CHAR_NAME
-    if len(targets) == 0 and args[0].isdigit():
-        targets = client.server.client_manager.get_targets(
-            client, TargetType.ID, int(args[0]), all_hub=True
-        )
+    targets = []
+    ids = args[0].split(",")
+    if len(ids) > 1 and all(i.isdigit() for i in ids):
+        for i in ids:
+            for target in client.server.client_manager.get_targets(
+                client, TargetType.ID, int(i), all_hub=True
+            ):
+                if target not in targets:
+                    targets.append(target)
         key = TargetType.ID
-    if len(targets) == 0:
+    else:
         targets = client.server.client_manager.get_targets(
-            client, TargetType.OOC_NAME, arg, local=True
+            client, TargetType.CHAR_NAME, arg, local=True
         )
-        key = TargetType.OOC_NAME
+        key = TargetType.CHAR_NAME
+        if len(targets) == 0 and args[0].isdigit():
+            targets = client.server.client_manager.get_targets(
+                client, TargetType.ID, int(args[0]), all_hub=True
+            )
+            key = TargetType.ID
+        if len(targets) == 0:
+            targets = client.server.client_manager.get_targets(
+                client, TargetType.OOC_NAME, arg, local=True
+            )
+            key = TargetType.OOC_NAME
     if len(targets) == 0:
         raise ArgumentError("No targets found.")
     try:
@@ -182,28 +195,40 @@ def ooc_cmd_pm(client, arg):
     except Exception:
         raise ArgumentError(
             "Not enough arguments. Use /pm <target> <message>.")
-    c = targets[0]
-    if c.pm_mute:
-        raise ClientError("This user muted all pm conversation")
-    else:
+    conversation = ", ".join(f"[{c.id}] {c.showname}" for c in targets)
+    sent = []
+    muted = []
+    for c in targets:
+        if c.pm_mute:
+            muted.append(f"[{c.id}] {c.showname}")
+            continue
         if c.is_mod:
-            c.send_ooc(
-                "📨PM from {} (ID: {}, IPID: {}) in {} ({}): {}".format(
-                    client.name,
-                    client.id,
-                    client.ipid,
-                    client.area.name,
-                    client.showname,
-                    msg,
-                )
+            header = "📨PM from {} (ID: {}, IPID: {}) in {} ({})".format(
+                client.name,
+                client.id,
+                client.ipid,
+                client.area.name,
+                client.showname,
             )
         else:
-            c.send_ooc(
-                "📨PM from {} (ID: {}) in {} ({}): {}".format(
-                    client.name, client.id, client.area.name, client.showname, msg
-                )
+            header = "📨PM from {} (ID: {}) in {} ({})".format(
+                client.name, client.id, client.area.name, client.showname
             )
-        client.send_ooc("📤PM sent to {}. Message: {}".format(args[0], msg))
+        if len(targets) > 1:
+            header += f" to {conversation}"
+        c.send_ooc(f"{header}: {msg}")
+        sent.append(f"[{c.id}] {c.showname}")
+    if len(sent) == 0:
+        if len(targets) == 1:
+            raise ClientError("This user muted all pm conversation")
+        raise ClientError("Every user you tried to PM muted all pm conversation")
+    client.send_ooc("📤PM sent to {}. Message: {}".format(", ".join(sent), msg))
+    if len(muted) > 0:
+        client.send_ooc(
+            "📵Could not reach {}, they muted all pm conversation.".format(
+                ", ".join(muted)
+            )
+        )
 
 
 def ooc_cmd_mutepm(client, arg):

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -322,6 +322,10 @@ class AOProtocol(asyncio.Protocol):
         self.client.send_motd()
         self.client.send_hub_info()
 
+        if not self.client.joined:
+            self.client.joined = True
+            self.client.area.area_manager.send_arup_players()
+
     def net_cmd_cc(self, args):
         """Character selection.
 

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -325,6 +325,7 @@ class AOProtocol(asyncio.Protocol):
         if not self.client.joined:
             self.client.joined = True
             self.client.area.area_manager.send_arup_players()
+            self.server.player_state_observer.register_client(self.client)
 
     def net_cmd_cc(self, args):
         """Character selection.
@@ -1083,7 +1084,10 @@ class AOProtocol(asyncio.Protocol):
         if self.client.used_showname_command:
             showname = self.client.showname
         self.client.showname = showname
-        
+        if self.client.showname != old_showname:
+            self.server.player_state_observer.notify_character_name_changed(
+                self.client)
+
         # Here, we check the pair stuff, and save info about it to the client.
         # Notably, while we only get a charid_pair and an offset, we send back a chair_pair, an emote, a talker offset
         # and an other offset.
@@ -1668,7 +1672,9 @@ class AOProtocol(asyncio.Protocol):
             )
             return
 
-        self.client.name = args[0]
+        if self.client.name != args[0]:
+            self.client.name = args[0]
+            self.server.player_state_observer.notify_name_changed(self.client)
         if args[1].lstrip() != args[1] and args[1].lstrip().startswith("/"):
             self.client.send_ooc(
                 "Your message was not sent for safety reasons: you left space before that slash."

--- a/server/playerstateobserver.py
+++ b/server/playerstateobserver.py
@@ -1,0 +1,151 @@
+class PlayerStateObserver:
+    """
+    Keeps the client side player list in sync with the AO 2.11 packets.
+
+    Registration:
+        PR#<player_id: int>#<update_type: int>#%
+    Player data:
+        PU#<player_id: int>#<data_type: int>#<data: string>#%
+
+    Clients older than 2.11 drop both packets, so they are sent unconditionally.
+    """
+
+    ADD = 0
+    REMOVE = 1
+
+    NAME = 0
+    CHARACTER = 1
+    CHARACTER_NAME = 2
+    AREA_ID = 3
+
+    def __init__(self, server):
+        self.server = server
+        # Clients that receive player list packets.
+        self.client_list = []
+        # Clients that are currently listed for everyone else.
+        self.listed = set()
+
+    def register_client(self, client):
+        """Hand the client the player list, then announce it to everyone else."""
+        if client in self.client_list:
+            return
+        self.client_list.append(client)
+        self.send_player_list(client)
+        self.notify_visibility_changed(client)
+
+    def unregister_client(self, client):
+        """Drop the client from the player list of everyone still connected."""
+        if client not in self.client_list:
+            return
+        self.client_list.remove(client)
+        if client in self.listed:
+            self.listed.discard(client)
+            self.send_to_client_list(client, "PR", client.id, self.REMOVE)
+
+    def send_player_list(self, client):
+        """Send every listed player of the client's hub to that client."""
+        for other in self.client_list:
+            if other is client or other not in self.listed:
+                continue
+            if other.area.area_manager != client.area.area_manager:
+                continue
+            self.send_player_state(client, other)
+
+    def send_player_state(self, target, client):
+        """Send every field of a single player to one target."""
+        target.send_command("PR", client.id, self.ADD)
+        target.send_command("PU", client.id, self.NAME, client.name)
+        target.send_command("PU", client.id, self.CHARACTER, client.char_name)
+        target.send_command("PU", client.id,
+                            self.CHARACTER_NAME, client.showname)
+        target.send_command("PU", client.id, self.AREA_ID,
+                            self.get_area_id(target, client))
+
+    def get_area_id(self, target, client):
+        """
+        Get the index the client's area sits at in the target's own area list.
+        Every client gets its own area list, so this cannot be broadcast as one
+        value the way the other player data can.
+        """
+        try:
+            area_id = target.local_area_list.index(client.area)
+        except ValueError:
+            return -1
+        # The hub entry takes up the first slot of the area list.
+        if len(self.server.hub_manager.hubs) > 1:
+            area_id = area_id + 1
+        return area_id
+
+    def send_to_client_list(self, client, command, *args):
+        """Send a packet about the client to every player list of its hub."""
+        for target in self.client_list:
+            if target.area.area_manager != client.area.area_manager:
+                continue
+            target.send_command(command, *args)
+
+    def notify_name_changed(self, client):
+        if client not in self.listed:
+            return
+        self.send_to_client_list(
+            client, "PU", client.id, self.NAME, client.name)
+
+    def notify_character_changed(self, client):
+        """
+        Announce a character change. Picking a character also takes the client
+        out of spectator, so the listing itself may have to be added or dropped.
+        """
+        if client not in self.listed or client.hidden:
+            self.notify_visibility_changed(client)
+            return
+        self.send_to_client_list(
+            client, "PU", client.id, self.CHARACTER, client.char_name)
+        self.send_to_client_list(
+            client, "PU", client.id, self.CHARACTER_NAME, client.showname)
+
+    def notify_character_name_changed(self, client):
+        if client not in self.listed:
+            return
+        self.send_to_client_list(
+            client, "PU", client.id, self.CHARACTER_NAME, client.showname)
+
+    def notify_area_id_changed(self, client):
+        if client not in self.listed:
+            return
+        for target in self.client_list:
+            if target.area.area_manager != client.area.area_manager:
+                continue
+            target.send_command("PU", client.id, self.AREA_ID,
+                                self.get_area_id(target, client))
+
+    def notify_visibility_changed(self, client):
+        """Add or drop the listing of a client that hid or revealed itself."""
+        if client not in self.client_list:
+            return
+        if client.hidden:
+            if client in self.listed:
+                self.listed.discard(client)
+                self.send_to_client_list(
+                    client, "PR", client.id, self.REMOVE)
+            return
+        if client in self.listed:
+            return
+        self.listed.add(client)
+        for target in self.client_list:
+            if target.area.area_manager != client.area.area_manager:
+                continue
+            self.send_player_state(target, client)
+
+    def notify_hub_changed(self, client, old_hub):
+        """Move the client's listing over to the hub it just joined."""
+        if client not in self.client_list:
+            return
+        for other in self.client_list:
+            if other is not client and other.area.area_manager == old_hub:
+                client.send_command("PR", other.id, self.REMOVE)
+        if client in self.listed:
+            self.listed.discard(client)
+            for target in self.client_list:
+                if target is not client and target.area.area_manager == old_hub:
+                    target.send_command("PR", client.id, self.REMOVE)
+        self.send_player_list(client)
+        self.notify_visibility_changed(client)

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -14,6 +14,7 @@ import server.logger
 from server import database
 from server.hub_manager import HubManager
 from server.client_manager import ClientManager
+from server.playerstateobserver import PlayerStateObserver
 from server.emotes import Emotes
 from server.discordbot import Bridgebot
 from server.exceptions import ClientError, ServerError
@@ -115,6 +116,7 @@ class TsuServer3:
 
         self.medieval_parser = MedievalParser()
         self.client_manager = ClientManager(self)
+        self.player_state_observer = PlayerStateObserver(self)
         server.logger.setup_logging(debug=self.config["debug"])
 
         self.webhooks = Webhooks(self)
@@ -280,6 +282,7 @@ class TsuServer3:
                 area.broadcast_ooc(
                     f"[{client.id}] {client.showname} has disconnected.")
             area.remove_client(client)
+        self.player_state_observer.unregister_client(client)
         self.client_manager.remove_client(client)
 
     @property


### PR DESCRIPTION
This aims to introduce the ARUP  PR/PU player list updater for modern compatibility with AO2 and AsyncAO.

This only affects AO client users and AsyncaAO

The DRO playerlist is kept unchanged for those clients that rely on a different one instead.

Needs proper testing before merging.

Also added a better way of improving /pm messaging you can now /pm 1,2,3 and it will send them all a message at the same time multiple IDS at once.