### PR TITLE
Automation overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ characters
 # Folder
 characters/
 
+### AI agent working files
+AGENTS.md
+docs/ai/
+
 ### Python related
 # Virtual environments
 venv/

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -106,6 +106,11 @@ ooc_floodguard:
 # Set to 0 or less to disable demo rate limiting entirely. (Default: 1000)
 demo_rate_limit_ms: 1000
 
+# Maximum number of instructions a demo script may execute before playback is
+# stopped. Guards against runaway loops (e.g. an accidental `goto` that never
+# exits). (Default: 100000)
+demo_max_steps: 100000
+
 # How many subscripts zalgo is stripped by; 3 is recommended as not to hurt special language diacritics
 zalgo_tolerance: 3
 

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -102,6 +102,10 @@ ooc_floodguard:
   interval_length: 5
   mute_length: 30
 
+# Minimum milliseconds between /demo calls before rate limiting kicks in.
+# Set to 0 or less to disable demo rate limiting entirely. (Default: 1000)
+demo_rate_limit_ms: 1000
+
 # How many subscripts zalgo is stripped by; 3 is recommended as not to hurt special language diacritics
 zalgo_tolerance: 3
 

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -103,13 +103,13 @@ ooc_floodguard:
   mute_length: 30
 
 # Minimum milliseconds between /demo calls before rate limiting kicks in.
-# Set to 0 or less to disable demo rate limiting entirely. (Default: 1000)
-demo_rate_limit_ms: 1000
+# Set to 0 or less to disable demo rate limiting entirely. (Default: 0)
+demo_rate_limit_ms: 0
 
 # Maximum number of instructions a demo script may execute before playback is
 # stopped. Guards against runaway loops (e.g. an accidental `goto` that never
-# exits). (Default: 100000)
-demo_max_steps: 100000
+# exits). (Default: 1000000)
+demo_max_steps: 1000000
 
 # How many subscripts zalgo is stripped by; 3 is recommended as not to hurt special language diacritics
 zalgo_tolerance: 3

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -717,6 +717,9 @@
         - When demo evidences are used, they are usually hidden and triggered by alternative means such as `/timer` or `/trigger present <id>`.
     - Use `/demo` to stop the running demos.
     - For more information on how demos work, [go here!](https://crystalwarrior.github.io/KFO-Wiki/guides/demo_guide/demo_guide/)
+* **stop\_demo** `[all]` *(GM)*
+    - Stop demo playback in the current area.
+    - Add `all` to stop demo playback in every area of the hub.
 * **trigger** `<trigger> <command> <arg(s)>` *(CM)*
     - Set up a trigger for this area which, when fulfilled, will call the command.
     - `trig` is the trigger keyword. Available keywords are `join`, `leave` and `present <id>` where `id`  is the evidence ID.

--- a/docs/demo_scripting.md
+++ b/docs/demo_scripting.md
@@ -1,0 +1,495 @@
+# Demo Scripting Guide
+
+Scripts run out of **evidence items**. Put a script in an evidence description,
+then play it with `/demo <id>` or `/demo <name>`. The server runs the script as
+the area's own character, so whatever the script broadcasts appears in the area.
+
+Here's the whole language at a glance:
+
+| Instruction                    | What it does                                  |
+| ------------------------------ | --------------------------------------------- |
+| `wait <ms>`                    | Pause for `<ms>` milliseconds                 |
+| `MS#...#%`, `CT#...#%`, etc.   | Send an AO packet to everyone in the area     |
+| `/command <args>%`             | Run an OOC command as the area's character    |
+| `set <var> <value>`            | Store a value in a variable                   |
+| `get <var> <source>`           | Read live server state into a variable        |
+| `concat <var> <value> <sep>`   | Add text to the end of a string variable      |
+| `rand <var> <min> <max>`       | Store a random whole number in a variable     |
+| `if <a> <op> <b> <label>`      | Jump to a label when a comparison is true     |
+| `label <name>`                 | Mark a spot to jump to                        |
+| `goto <name>`                  | Jump to a label (remembering where you were)  |
+| `return`                       | Jump back to the matching `goto`; if there's  |
+|                                | nothing to return to, the script just ends    |
+
+## Writing a script
+
+A script is a list of lines. How a line ends depends on what it is:
+
+- **Packets and `/` commands end with `%`.** They can even span multiple lines -
+  the newlines inside them are part of the packet. A multi-line message works
+  fine:
+  ```
+  CT#narrator#Hello..
+  there..
+  everyone!!!%
+  ```
+- **Everything else ends with `%` *or* a newline.**
+  That means you can write a script with real line breaks:
+
+  ```
+  set count 5
+  label loop
+  set count count-1
+  if count gt 0 loop
+  CT#narrator#Blastoff!%
+  ```
+
+  This is the same script but written using % as a one-liner:
+
+  ```
+  set count 5%label loop%set count count-1%if count gt 0 loop%CT#narrator#Blastoff!%
+  ```
+
+  Mix and match however you like. `%` is only *required* when you want several
+  things on one physical line, but it absolutely will hurt readability.
+
+Pre-scripting demos still work:
+
+- A stray `#` before the `%` is ignored (`wait#5000#%` and `wait#5000%` are the same thing).
+- `wait#5000#%` and `wait 5000` mean the same thing.
+
+Within a line, spaces separate the parts. If a value itself contains spaces,
+put it in quotes: `set greeting "Hello there"`.
+
+## The absolute basics
+
+### Wait Packet
+
+**To pause, use** `wait <milliseconds>`, so one second is 1000 milliseconds.
+
+```
+CT#narrator#Scene change incoming!%
+wait 3000
+BN#BOTC-TownSquare%
+```
+
+### Commands
+
+Any `/` command works, exactly as if a User typed it. ([Command Reference](https://github.com/Crystalwarrior/KFO-Server/blob/master/docs/commands.md)) Remember,
+commands need their `%`:
+
+```
+/say Welcome to the roleplay!%
+/timer 0 60s start%
+/pos_lock wit%
+```
+
+### Packets
+
+**Packets**, aka what you use to send information to the user's client,
+is the header followed by `#`-separated fields. A demo may
+broadcast these headers: `MS`, `CT`, `MC`, `BN`, `HP`, `RT`, `JD`, `GM`, `ST`.
+(if choosing between "Client" and "Server" version of the packet, use the "Server" packet)
+
+```
+CT#narrator#Hello everyone!%
+MC#~stop.mp3#-1##1#0#5%
+BN#BOTC-TownSquare%
+```
+
+* [MS packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/MS%20Packet%20Reference.md) is the in-character message.
+* [CT packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#CT-Server) is the OOC message.
+* [MC packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#MC) is the Music Change packet and is responsible for playing music (use "Client as Receiver" version of the packet)
+* [BN packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#BN) is the Background Name packet and is responsbile for changing the background.
+* [HP packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#hp) updates the penalty bar values.
+* [RT packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#rt) is the witness testimony, cross examination, or an arbitrary animation with a noise. It is unaffected by the message queue and shows up instantly.
+* [JD packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#jd) decides if the judge controls (WTCE, penalty + - buttons in the theme) should appear or hide for the client.
+* GM packet is the DRO GameMode packet. It decides what theme gamemode to set (Prefer using /subtheme)
+* [ST packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#ST) is the SubTheme packet. It decides what subtheme of the theme to use. (Prefer using /subtheme)
+
+Note that packets do not change state - this means that if you use BN, it will ONLY apply the
+Background for the clients that received that packet until something else sends it again, while
+/bg actually changes the area's Background persistantly meaning anyone new entering this area will
+see the new background as well. This means you should prefer to use /commands unless you want to
+send an IC message or don't want to modify the area details!
+
+
+## Variables
+
+Variables are user-defined names - `count`, `showname`, `score`, etc. - that hold one
+value. They live on the area, so they're shared by every demo and trigger
+running within that area.
+
+```
+set count 5
+set count count+1   // adds 1, so count is now 6
+set name "Miles"
+set alias name      // alias copies name: "Miles"
+```
+
+Anything that isn't a quoted string or a variable name is treated as a math
+expression. `+ - * / ( ) .` are all allowed:
+
+```
+set gold 10
+set total gold*2+5  // total = 25
+get need players+2  // need = number of players + 2
+```
+
+If you write a bare word that isn't a variable, the script stops with an error.
+`set name Miles` without quotes fails, instead write `set name "Miles"`.
+
+## Strings
+
+Text goes in quotes, `"..."` or `'...'`. You can copy one variable into
+another, and `if` can compare strings directly:
+
+```
+set name "Alice"                  // The name we're gonna use here
+if name == "Alice" greet          // if name equals to Alice, go to the greet label
+if name != "Bob" nogreet          // if name equals to Alice, go to the nogreet label
+label greet
+CT#narrator#Hello, <!name>!%      // Hello, Alice!
+goto finish                       // Skip ahead so we don't say Goodbye by accident
+label nogreet
+CT#narrator#Goodbye, <!name>!%    // Goodbye, Bob!
+label finish
+CT#narrator#I eat boogers!%
+```
+
+Ordering comparisons (`==` equal to, `!=` not equal to, `<` less than, `>` greater than, `<=` less or equal to, `>=` greater or equal to) need both sides to be the same
+kind - two numbers, or two strings. Comparing a number to a string stops the
+script with an error.
+
+## Putting live values in your text
+
+`<!name>` anywhere in a packet or command drops in the current value:
+
+```
+set count 5
+CT#narrator#Only <!count> more minutes!%
+/say The score is <!score>%
+```
+
+You can also drop live state straight in - see below - so `<!players>` works
+too.
+
+## Reading the server's state
+
+`get` reads a value and stores it in a variable. These special names are
+always available:
+
+| Name                  | What you get                              |
+| --------------------- | ----------------------------------------- |
+| `players`             | How many people are in the area           |
+| `max_players`         | The area's player cap                     |
+| `hp_def`              | The defense HP bar value                  |
+| `hp_pro`              | The prosecution HP bar value              |
+| `char_count`          | How many characters are on the server     |
+
+```
+get total players
+CT#narrator#There are <!total> players here!%
+```
+
+### Digging deeper with paths
+
+`get` can also walk into the server's state with a **path**:
+
+| Path                    | What you get                                |
+| ----------------------- | ------------------------------------------- |
+| `clients.count`         | Number of real clients in the area          |
+| `client[i].<field>`     | Something about the i-th person in the area |
+| `timer[i].<field>`      | Something about the i-th timer              |
+| `area.<field>`          | Something about the current area            |
+| `hub.<field>`           | Something about the current hub             |
+
+`client[0]` is the first person in the area, `client[1]` the second, and so on
+- in the same order `/getarea` lists them. You can even use a custom variable as the
+index: `client[i]`, `client[i+1]`.
+
+```
+get first client[0].showname
+CT#narrator#First in the room: <!first>%
+```
+
+**Timers.** Timer numbers are the same ones `/timer` shows: `timer[0]` is the
+hub-wide timer, `timer[1]` through `timer[20]` are the area's own.
+
+| Field           | What you get                                  |
+| --------------- | --------------------------------------------- |
+| `remaining_ms`  | Millis left on the timer (0 if it isn't set)  |
+| `static_ms`     | The time the timer was set to (0 if unset)    |
+| `set`           | `1` if the timer is set/shown, else `0`       |
+| `started`       | `1` if the timer is running, else `0`         |
+
+```
+get left timer[3].remaining_ms
+if left == 0 timeout
+CT#narrator#<left> ms left on the deliberation timer!%
+```
+
+**What you can read from a person:** `id`, `char_id`, `char_name`, `showname`,
+`name` (their OOC name), `char_folder`, `pos`, `pair`, `iniswap`,
+`last_move_time` (ms since their last action), `remote_listen`, `subtheme`,
+`time_of_day`, `char_url`, and the yes/no flags `is_cm`, `is_gm`, `is_owner`,
+`is_afk`, `hidden`, `blinded`, `sneaking`, `frozen`. Moderator-only
+details like IP/HDID hashes and `is_mod` are not exposed to scripts.
+
+```
+if client[i].hidden eq 1 skip
+get showname client[i].showname
+concat list showname ", "
+```
+
+**What you can read from the area:**
+
+- Identity and description: `name`, `id`, `abbreviation`, `desc`, `status`, `doc`
+- Background and position: `background`, `background_dark`, `background_suffix`,
+  `overlay`, `pos_lock` (space-separated positions, empty when unlocked),
+  `bg_lock`, `overlay_lock`, `pos_dark`, `desc_dark`, `dark`
+- Permissions and behavior: `can_cm`, `locking_allowed`, `iniswap_allowed`,
+  `showname_changes_allowed`, `shouts_allowed`, `non_int_pres_only`,
+  `evidence_mod`, `blankposting_allowed`, `blankposting_forced`,
+  `ooc_actions_enabled`, `present_reveals_evidence`, `passing_msg`,
+  `can_whisper`, `can_wtce`, `can_change_status`, `can_spectate`, `can_getarea`,
+  `use_backgrounds_yaml`, `hide_clients`, `force_sneak`, `locked`, `muted`,
+  `password`, `hidden`, `max_players`, `hp_def`, `hp_pro`, `move_delay`,
+  `msg_delay`, `medieval_mode`
+- Music: `music`, `music_autoplay`, `music_looping`, `music_effects`,
+  `music_ref`, `replace_music`, `client_music`, `ambience`, `can_dj`, `jukebox`,
+  `music_locked`
+- Minigames: `can_battle`, `auto_pair`, `auto_pair_max`, `auto_pair_cycle`,
+  `can_cross_swords`, `can_scrum_debate`, `can_panic_talk_action`, and the
+  matching `*_song_start`, `*_song_end`, `*_song_concede` tracks
+
+The yes/no flags above return `1` or `0`.
+
+**What you can read from the hub:** `name`, `id`, `abbreviation`, `subtheme`,
+`time_of_day`, `doc` (its description), `info` (same as `doc`), `char_count`,
+`char_list_ref`, `music_ref`, `move_delay`, `current_areas` (how many areas the
+hub has), and the yes/no flags `arup_enabled`, `hide_clients`, `can_gm`,
+`single_cm`, `replace_music`, `client_music`, `can_spectate`, `can_getareas`,
+`passing_msg`, `autokick_to_latest_area`, plus `max_areas`.
+
+Only these fields exist - scripts can't reach into anything else on the server.
+If you ask for a path or field that doesn't exist, the script stops with an
+error.
+
+## Joining text: `concat`
+
+`concat` adds text to the end of a string variable. Handy for making a list of
+names:
+
+```
+set list ""
+concat list "Miles"
+concat list "Apollo" ", "     # list is now "Miles, Apollo"
+CT#narrator#Players here: <!list>%
+```
+
+The third part is the separator, and it only appears *between* items - so the
+list never starts or ends with a comma. The separator is optional.
+
+## Random numbers: `rand`
+
+`rand` stores a random whole number between `min` and `max`, both ends
+included:
+
+```
+rand roll 1 6
+CT#narrator#You rolled a <!roll>!%
+```
+
+The bounds can be numbers, expressions, or variables. If `min` is bigger than
+`max`, the script stops with an error.
+
+## Making decisions: `if`
+
+`if` jumps to a label when a comparison is true:
+
+```
+if total ge 5 full
+CT#narrator#Plenty of room!%
+label full
+```
+
+The comparisons are `eq` (equal), `ne` (not equal), `lt` (less than), `gt`
+(greater than), `le` (less or equal), `ge` (greater or equal). The usual
+symbols work too: `==`, `!=`, `<`, `>`, `<=`, `>=`.
+
+```
+if count == 0 done
+if count > 0 keepgoing
+if name != "Alice" alert
+```
+
+Both sides can be numbers, strings, variables, or live paths - anything a value
+can be.
+
+## Loops and subroutines
+
+`label` marks a spot, `goto` jumps to it. That's how you loop:
+
+```
+set count 5
+label loop
+CT#narrator#<!count>!%
+wait 1000
+set count count-1
+if count > 0 loop
+CT#narrator#Blastoff!%
+```
+turns into: 5! 4! 3! 2! 1! Blastoff!
+
+`goto` remembers where it came from, and `return` jumps back. Use that for a
+"subroutine" you want to run from several places:
+
+```
+goto roll_for_damage
+goto roll_for_damage
+label done
+...
+label roll_for_damage
+rand dmg 1 8
+CT#narrator#You dealt <!dmg> damage!%
+return
+```
+
+If `return` has nowhere to return to, the script just ends - no error. So you
+can use a bare `return` at the end of a script to stop it early. Labels are
+scoped to the current script, and jumping to a label that doesn't exist stops
+the script.
+
+## When things go wrong
+
+- Any error prints `[Demo] [ERROR] ...` to the area and stops the script. The
+  area's HP bars and background are restored before it stops.
+- A script can't run forever. After 100,000 steps it stops on its own
+  (configurable in `config.yaml` as `demo_max_steps`) - so an accidental
+  infinite loop can't stall the server.
+- `/stop_demo` (GMs and mods) stops playback at any time, and `/demo` with no
+  argument does too.
+
+## A couple of extras
+
+**Chaining.** A script can run another demo:
+
+```
+/demo 3%
+```
+
+That *replaces* the current script with demo 3 - labels start over. It's a
+jump, not a subroutine; use `goto`/`return` within the same demo if you want to come back.
+
+**Escaping.** If your text ever needs a literal `#`, `&`, `%`, or `$`, write
+them as `<num>`, `<and>`, `<percent>`, `<dollar>`. Use `<percent>` if you need
+a `%` inside a quoted value.
+
+## Timers
+
+Every area has 21 countdown timers: `0` is hub-wide, `1` through `20` belong to
+the area. Anyone can check a timer with `/timer <id>`; setting and changing
+them takes CM/GM rights (and timer `0` needs GM):
+
+```
+/timer 1 5m          set timer 1 to 5 minutes
+/timer 1 start       start the countdown
+/timer 1 pause       pause it (or `stop`)
+/timer 1 +30s        add 30 seconds to whatever it's at now
+/timer 1 unset       hide it and forget its time (or `hide`)
+```
+
+Your script reads timers through the live paths from the table above:
+
+```
+get left timer[3].remaining_ms
+if left == 0 timeout
+CT#narrator#<left> ms left on the deliberation timer!%
+```
+
+### Run a script when the timer expires
+
+A timer holds a stack of commands that run the moment it hits zero. Queue them
+in OOC with `/timer <id> /<command>`:
+
+```
+/timer 1 /demo 3               run demo 3 when timer 1 expires
+/timer 1 /h Time's up!         announce it in hub chat
+/timer 1 /timer 1 hide         also hide the timer when it expires
+/timer 1 /clear                wipe all queued commands
+/timer 1 /                     list what's queued
+```
+
+These lines are ordinary OOC commands, so a demo can arm a timer too - put
+`/timer 1 5m start%` in your script and it sets and starts the timer, and a
+`/timer 1 /demo 4%` line queues demo 4 to run on expiry. Commands run in order
+through the area's system executor (the same headless client that runs demos),
+so they fire even with no CM/GM online. A demo started this way shares the
+area's variables with everything else.
+
+## Triggers
+
+Triggers watch for something happening in the area and run a command when it
+does. Area triggers are `join` and `leave`; an evidence item can also have a
+`present` trigger. Only normal players set them off - hidden clients, CMs,
+GMs and mods are ignored.
+
+```
+/trigger join /demo 2
+/trigger leave /h <showname> left
+/trigger present 1 /demo 4
+```
+
+The command runs through the area's system executor, so it works even if no
+CM or GM is around. You can type these in OOC or also use them as script lines!
+
+**Inline variables.** Before the command runs, three placeholders are replaced
+with the player who caused the trigger: `<cid>`, `<showname>`, and `<char>`.
+`/trigger join /g <showname> just joined!` becomes `/g Miles just joined!`
+when Miles joins.
+
+**Script context.** A trigger also drops three values into the area's script
+variables, which a `/demo` it runs can read:
+
+| Variable            | What you get                          |
+| ------------------- | ------------------------------------- |
+| `trigger_cid`       | The player's client ID                |
+| `trigger_showname`  | Their showname                        |
+| `trigger_char`      | Their character name                  |
+
+So demo 2 could greet the person who triggered it:
+
+```
+/trigger join /demo 2
+```
+
+```
+CT#narrator#Welcome to the area, <!trigger_showname>!%
+```
+
+The values stay until the next trigger fires (or a script overwrites them), so
+a demo has time to pick them up.
+
+**One shared state.** Demos, trigger commands and timer-expiry commands all run
+in the same area and share `area.variables`. A demo can leave a flag behind for
+a trigger to check, and a trigger's demo can set things up for a timer expiry
+that comes later.
+
+## Example: list everyone present
+
+```
+set i 0
+get total clients.count
+set list ""
+label loop
+if i ge total done
+if client[i].hidden eq 1 skip
+get showname client[i].showname
+concat list showname ", "
+label skip
+set i i+1
+goto loop
+label done
+CT#narrator#Players here: <!list>%
+```

--- a/docs/demo_scripting.md
+++ b/docs/demo_scripting.md
@@ -196,13 +196,17 @@ CT#narrator#There are <!total> players here!%
 
 `get` can also walk into the server's state with a **path**:
 
-| Path                    | What you get                                |
-| ----------------------- | ------------------------------------------- |
-| `clients.count`         | Number of real clients in the area          |
-| `client[i].<field>`     | Something about the i-th person in the area |
-| `timer[i].<field>`      | Something about the i-th timer              |
-| `area.<field>`          | Something about the current area            |
-| `hub.<field>`           | Something about the current hub             |
+| Path                      | What you get                                  |
+| ------------------------- | --------------------------------------------- |
+| `clients.count`           | Number of real clients in the area            |
+| `client[i].<field>`       | Something about the i-th person in the area   |
+| `timer[i].<field>`        | Something about the i-th timer                |
+| `evidence.count`          | Number of evidence items in the area          |
+| `evidence[i].<field>`     | Something about the i-th evidence item        |
+| `links.count`             | Number of area links                          |
+| `links[i].<field>`        | Something about the i-th area link            |
+| `area.<field>`            | Something about the current area              |
+| `hub.<field>`             | Something about the current hub               |
 
 `client[0]` is the first person in the area, `client[1]` the second, and so on
 - in the same order `/getarea` lists them. You can even use a custom variable as the
@@ -271,6 +275,49 @@ The yes/no flags above return `1` or `0`.
 hub has), and the yes/no flags `arup_enabled`, `hide_clients`, `can_gm`,
 `single_cm`, `replace_music`, `client_music`, `can_spectate`, `can_getareas`,
 `passing_msg`, `autokick_to_latest_area`, plus `max_areas`.
+
+**What you can read from an evidence item.** `evidence[i]` is the i-th piece
+of evidence, 0-based, in the order the area lists it. Fields: `name`, `desc`,
+`image`, `pos` (the positions it shows in), `show_in_dark` (0 = never in dark
+areas, 1 = always, 2 = only in dark areas), and the yes/no flags `can_hide_in`,
+`can_take`, `editable`. Who is hiding inside a piece of evidence is not
+exposed.
+
+```
+get count evidence.count
+set i 0
+label loop
+if i ge count done
+get item evidence[i].name
+CT#narrator#Evidence <!i>: <!item>%
+set i i+1
+goto loop
+label done
+```
+
+**What you can read from an area link.** A link is a one-way connection to
+another area. `links[i]` is 0-based, in the order the links were created.
+Fields: `target` (the area ID the link leads to), `target_pos` (the position
+you arrive in), `evidence` (space-separated evidence IDs you must have to pass
+through), `password`, and the yes/no flags `locked`, `hidden`, `can_peek`.
+
+```
+get count links.count
+set i 0
+label loop
+if i ge count done
+get target links[i].target
+get locked links[i].locked
+if locked eq 1 blocked
+CT#narrator#To area <!target>: open%
+goto next
+label blocked
+CT#narrator#To area <!target>: locked%
+label next
+set i i+1
+goto loop
+label done
+```
 
 Only these fields exist - scripts can't reach into anything else on the server.
 If you ask for a path or field that doesn't exist, the script stops with an

--- a/docs/demo_scripting.md
+++ b/docs/demo_scripting.md
@@ -121,6 +121,9 @@ Variables are user-defined names - `count`, `showname`, `score`, etc. - that hol
 value. They live on the area, so they're shared by every demo and trigger
 running within that area.
 
+A `//` marks the rest of a line as a comment - the script skips it, so the
+examples use it to explain what each line does:
+
 ```
 set count 5
 set count count+1   // adds 1, so count is now 6
@@ -148,7 +151,7 @@ another, and `if` can compare strings directly:
 ```
 set name "Alice"                  // The name we're gonna use here
 if name == "Alice" greet          // if name equals to Alice, go to the greet label
-if name != "Bob" nogreet          // if name equals to Alice, go to the nogreet label
+if name != "Bob" nogreet          // if name isn't Bob, go to the nogreet label
 label greet
 CT#narrator#Hello, <!name>!%      // Hello, Alice!
 goto finish                       // Skip ahead so we don't say Goodbye by accident
@@ -169,6 +172,7 @@ script with an error.
 ```
 set count 5
 CT#narrator#Only <!count> more minutes!%
+set score 10
 /say The score is <!score>%
 ```
 
@@ -276,9 +280,11 @@ The flags below come back as `1` (yes) or `0` (no):
 | `frozen`     | They're frozen                |
 
 ```
+set i 0
 if client[i].hidden == 1 skip
 get showname client[i].showname
 concat list showname ", "
+label skip
 ```
 
 For safety, mod-only details such as IP/HDID hashes and `is_mod` are never
@@ -522,6 +528,7 @@ number (or expression), a quoted string, a variable, or a live path:
 ```
 save "Phoenix" title "Attorney"
 save 0 points 5
+set gold 10
 save 0 gold gold+10
 save 0 lastarea area.name
 ```
@@ -533,12 +540,12 @@ you save here is there next time the server restarts.
 
 **GMs** can inspect and edit the same data from OOC without a demo:
 
-```
-/get_char_data Phoenix            lists every key for the character
-/get_char_data Phoenix title      shows just that key
-/set_char_data Phoenix title Attorney   sets a key
-/set_char_data Phoenix title            removes the key (no value)
-```
+| Command | What it does |
+| --- | --- |
+| `/get_char_data Phoenix` | lists every key for the character |
+| `/get_char_data Phoenix title` | shows just that key |
+| `/set_char_data Phoenix title Attorney` | sets a key |
+| `/set_char_data Phoenix title` | removes the key (no value) |
 
 Character data is one of the few places a demo writes persistent state, so it
 doubles as a shared "blackboard": a trigger's demo can `save` a flag that a
@@ -553,7 +560,7 @@ names:
 ```
 set list ""
 concat list "Miles"
-concat list "Apollo" ", "     # list is now "Miles, Apollo"
+concat list "Apollo" ", "     // list is now "Miles, Apollo"
 CT#narrator#Players here: <!list>%
 ```
 
@@ -578,9 +585,12 @@ The bounds can be numbers, expressions, or variables. If `min` is bigger than
 `if` jumps to a label when a comparison is true:
 
 ```
+get total players
 if total >= 5 full
-CT#narrator#Plenty of area!%
+CT#narrator#Room's not full yet!%
+return
 label full
+CT#narrator#Room's full!%
 ```
 
 The comparisons use the usual symbols: `==` equal, `!=` not equal, `<` less
@@ -588,9 +598,17 @@ than, `>` greater than, `<=` less or equal, `>=` greater or equal. (The words
 `eq`, `ne`, `lt`, `gt`, `le`, `ge` mean the same thing and also work.)
 
 ```
-if count == 0 done
-if count > 0 keepgoing
-if name != "Alice" alert
+set count 3
+set name "Miles"
+if count == 3 three
+if name != "Alice" stranger
+CT#narrator#Checking done!%
+return
+label three
+CT#narrator#Count is three!%
+return
+label stranger
+CT#narrator#A stranger!%
 ```
 
 Both sides can be numbers, strings, variables, or live paths - anything a value
@@ -618,13 +636,16 @@ turns into: 5! 4! 3! 2! 1! Blastoff!
 ```
 goto roll_for_damage
 goto roll_for_damage
-label done
-...
+return
 label roll_for_damage
 rand dmg 1 8
 CT#narrator#You dealt <!dmg> damage!%
 return
 ```
+
+The two `goto`s run the same block twice - you see two damage rolls - then the
+`return` at the end of the main script finishes it (there's nothing left to
+return to).
 
 If `return` has nowhere to return to, the script just ends - no error. So you
 can use a bare `return` at the end of a script to stop it early. Labels are
@@ -637,19 +658,18 @@ Every area has 21 countdown timers: `0` is hub-wide, `1` through `20` belong to
 the area. Anyone can check a timer with `/timer <id>`; setting and changing
 them takes CM/GM rights (and timer `0` needs GM):
 
-```
-/timer 1 5m          set timer 1 to 5 minutes
-/timer 1 start       start the countdown
-/timer 1 pause       pause it (or `stop`)
-/timer 1 +30s        add 30 seconds to whatever it's at now
-/timer 1 unset       hide it and forget its time (or `hide`)
-```
+| Command | What it does |
+| --- | --- |
+| `/timer 1 5m` | set timer 1 to 5 minutes |
+| `/timer 1 start` | start the countdown |
+| `/timer 1 pause` | pause it (or `stop`) |
+| `/timer 1 +30s` | add 30 seconds to whatever it's at now |
+| `/timer 1 unset` | hide it and forget its time (or `hide`) |
 
 Your script reads timers through the live paths from the table above:
 
 ```
 get left timer[3].remaining_ms
-if left == 0 timeout
 CT#narrator#<!left> ms left on the deliberation timer!%
 ```
 
@@ -658,13 +678,13 @@ CT#narrator#<!left> ms left on the deliberation timer!%
 A timer holds a stack of commands that run the moment it hits zero. Queue them
 in OOC with `/timer <id> /<command>`:
 
-```
-/timer 1 /demo 3               run demo 3 when timer 1 expires
-/timer 1 /h Time's up!         announce it in hub chat
-/timer 1 /timer 1 hide         also hide the timer when it expires
-/timer 1 /clear                wipe all queued commands
-/timer 1 /                     list what's queued
-```
+| Command | What it does |
+| --- | --- |
+| `/timer 1 /demo 3` | run demo 3 when timer 1 expires |
+| `/timer 1 /h Time's up!` | announce it in hub chat |
+| `/timer 1 /timer 1 hide` | also hide the timer when it expires |
+| `/timer 1 /clear` | wipe all queued commands |
+| `/timer 1 /` | list what's queued |
 
 These lines are ordinary OOC commands, so a demo can arm a timer too - put
 `/timer 1 5m start%` in your script and it sets and starts the timer, and a
@@ -681,11 +701,11 @@ does. Area triggers are `join` and `leave`; an evidence item can also have a
 `present` trigger. Only normal players set them off - hidden clients, CMs,
 GMs and mods are ignored.
 
-```
-/trigger join /demo 2
-/trigger leave /h <showname> left
-/trigger present 1 /demo 4
-```
+| Command | Runs when |
+| --- | --- |
+| `/trigger join /demo 2` | someone joins |
+| `/trigger leave /h <showname> left` | someone leaves (announces in hub chat) |
+| `/trigger present 1 /demo 4` | evidence item 1 is presented |
 
 The command runs through the area's system executor, so it works even if no
 CM or GM is around. You can type these in OOC or also use them as script lines!
@@ -730,6 +750,10 @@ When the timer later runs its /demo 1 command, that script can check the note:
 
 ```
 if door_open == 1 open_the_door
+CT#narrator#The door stays shut.%
+return
+label open_the_door
+CT#narrator#The door is open!%
 ```
 
 The note is still there even though the demo that wrote it has finished.

--- a/docs/demo_scripting.md
+++ b/docs/demo_scripting.md
@@ -15,11 +15,11 @@ Here's the whole language at a glance:
 | `get <var> <source>`           | Read live server state into a variable        |
 | `concat <var> <value> <sep>`   | Add text to the end of a string variable      |
 | `rand <var> <min> <max>`       | Store a random whole number in a variable     |
+| `save <char> <key> <value>`    | Persist a value into a character's data       |
 | `if <a> <op> <b> <label>`      | Jump to a label when a comparison is true     |
 | `label <name>`                 | Mark a spot to jump to                        |
 | `goto <name>`                  | Jump to a label (remembering where you were)  |
-| `return`                       | Jump back to the matching `goto`; if there's  |
-|                                | nothing to return to, the script just ends    |
+| `return`                       | Jump back to the matching `goto`; if there's nothing to return to, the script just ends    |
 
 ## Writing a script
 
@@ -200,11 +200,14 @@ CT#narrator#There are <!total> players here!%
 | ------------------------- | --------------------------------------------- |
 | `clients.count`           | Number of real clients in the area            |
 | `client[i].<field>`       | Something about the i-th person in the area   |
+| `afk.count`               | Number of AFK clients in the area             |
+| `afk[i].<field>`          | Something about the i-th AFK client           |
 | `timer[i].<field>`        | Something about the i-th timer                |
 | `evidence.count`          | Number of evidence items in the area          |
 | `evidence[i].<field>`     | Something about the i-th evidence item        |
 | `links.count`             | Number of area links                          |
 | `links[i].<field>`        | Something about the i-th area link            |
+| `char[<name>].<key>`      | A saved value for a character (see below)     |
 | `area.<field>`            | Something about the current area              |
 | `hub.<field>`             | Something about the current hub               |
 
@@ -236,9 +239,12 @@ CT#narrator#<left> ms left on the deliberation timer!%
 **What you can read from a person:** `id`, `char_id`, `char_name`, `showname`,
 `name` (their OOC name), `char_folder`, `pos`, `pair`, `iniswap`,
 `last_move_time` (ms since their last action), `remote_listen`, `subtheme`,
-`time_of_day`, `char_url`, and the yes/no flags `is_cm`, `is_gm`, `is_owner`,
-`is_afk`, `hidden`, `blinded`, `sneaking`, `frozen`. Moderator-only
-details like IP/HDID hashes and `is_mod` are not exposed to scripts.
+`time_of_day`, `char_url`, `hidden_in` (the evidence index they're hiding in,
+empty if not hiding), `listen_pos` (space-separated positions they're listening
+to, empty while listening normally), and the yes/no flags `is_cm`, `is_gm`,
+`is_owner`, `is_afk`, `hidden`, `blinded`, `sneaking`, `frozen`.
+Moderator-only details like IP/HDID hashes and `is_mod` are not exposed to
+scripts.
 
 ```
 if client[i].hidden eq 1 skip
@@ -279,9 +285,9 @@ hub has), and the yes/no flags `arup_enabled`, `hide_clients`, `can_gm`,
 **What you can read from an evidence item.** `evidence[i]` is the i-th piece
 of evidence, 0-based, in the order the area lists it. Fields: `name`, `desc`,
 `image`, `pos` (the positions it shows in), `show_in_dark` (0 = never in dark
-areas, 1 = always, 2 = only in dark areas), and the yes/no flags `can_hide_in`,
-`can_take`, `editable`. Who is hiding inside a piece of evidence is not
-exposed.
+areas, 1 = always, 2 = only in dark areas), `hiding` (the showname of whoever
+is hiding inside, empty if empty), and the yes/no flags `can_hide_in`,
+`can_take`, `editable`.
 
 ```
 get count evidence.count
@@ -322,6 +328,60 @@ label done
 Only these fields exist - scripts can't reach into anything else on the server.
 If you ask for a path or field that doesn't exist, the script stops with an
 error.
+
+## Character data: remembering things between demos
+
+Area variables live and die with the demo. **Character data** is the
+persistent store: a bag of `key: value` pairs per character, saved to
+`config/character_data.yaml`, surviving restarts, and shared by every area in
+the hub. GMs already use it for keys, descriptions, movement delay and
+inventory; demos and triggers can use it for anything else.
+
+**Read** a saved value with the `char` path. `<name>` is a **character id**
+(the index into the server's character list — the number `/charids` shows,
+not the client/user id) or a quoted folder name (`char["Phoenix"]`):
+
+```
+get title char["Phoenix"].title
+CT#narrator#Hello, <!title>!%
+```
+
+The special keys `.count` (how many keys that character has) and `.fields`
+(their names, space-separated) don't need to be stored to be read. A key that
+was never saved reads back as an empty string; a list value reads back as its
+items joined with spaces.
+
+**Write** a value with `save`. The character is written the same way as the
+read path's `<name>` — a **character id** (index into the character list, as
+`/charids` shows) or a quoted folder name (`"Phoenix"`) — just without the
+brackets. The key is a plain word, and the value can be a
+number (or expression), a quoted string, a variable, or a live path:
+
+```
+save "Phoenix" title "Attorney"
+save 0 points 5
+save 0 gold gold+10
+save 0 lastarea area.name
+```
+
+Anything that isn't a number, variable, quoted string or live path is stored
+verbatim as a string, so `save 0 note He's holding a badge` stores exactly
+`He's holding a badge`. `save` writes the file to disk immediately, so data
+you save here is there next time the server restarts.
+
+**GMs** can inspect and edit the same data from OOC without a demo:
+
+```
+/get_char_data Phoenix            lists every key for the character
+/get_char_data Phoenix title      shows just that key
+/set_char_data Phoenix title Attorney   sets a key
+/set_char_data Phoenix title            removes the key (no value)
+```
+
+Character data is one of the few places a demo writes persistent state, so it
+doubles as a shared "blackboard": a trigger's demo can `save` a flag that a
+later timer-expiry demo reads with `char[...]`, and it survives the server
+being restarted in between.
 
 ## Joining text: `concat`
 

--- a/docs/demo_scripting.md
+++ b/docs/demo_scripting.md
@@ -28,11 +28,13 @@ A script is a list of lines. How a line ends depends on what it is:
 - **Packets and `/` commands end with `%`.** They can even span multiple lines -
   the newlines inside them are part of the packet. A multi-line message works
   fine:
+
   ```
   CT#narrator#Hello..
   there..
   everyone!!!%
   ```
+
 - **Everything else ends with `%` *or* a newline.**
   That means you can write a script with real line breaks:
 
@@ -40,14 +42,14 @@ A script is a list of lines. How a line ends depends on what it is:
   set count 5
   label loop
   set count count-1
-  if count gt 0 loop
+  if count > 0 loop
   CT#narrator#Blastoff!%
   ```
 
   This is the same script but written using % as a one-liner:
 
   ```
-  set count 5%label loop%set count count-1%if count gt 0 loop%CT#narrator#Blastoff!%
+  set count 5%label loop%set count count-1%if count > 0 loop%CT#narrator#Blastoff!%
   ```
 
   Mix and match however you like. `%` is only *required* when you want several
@@ -61,7 +63,7 @@ Pre-scripting demos still work:
 Within a line, spaces separate the parts. If a value itself contains spaces,
 put it in quotes: `set greeting "Hello there"`.
 
-## The absolute basics
+## The Basics
 
 ### Wait Packet
 
@@ -97,22 +99,21 @@ MC#~stop.mp3#-1##1#0#5%
 BN#BOTC-TownSquare%
 ```
 
-* [MS packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/MS%20Packet%20Reference.md) is the in-character message.
-* [CT packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#CT-Server) is the OOC message.
-* [MC packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#MC) is the Music Change packet and is responsible for playing music (use "Client as Receiver" version of the packet)
-* [BN packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#BN) is the Background Name packet and is responsbile for changing the background.
-* [HP packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#hp) updates the penalty bar values.
-* [RT packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#rt) is the witness testimony, cross examination, or an arbitrary animation with a noise. It is unaffected by the message queue and shows up instantly.
-* [JD packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#jd) decides if the judge controls (WTCE, penalty + - buttons in the theme) should appear or hide for the client.
-* GM packet is the DRO GameMode packet. It decides what theme gamemode to set (Prefer using /subtheme)
-* [ST packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#ST) is the SubTheme packet. It decides what subtheme of the theme to use. (Prefer using /subtheme)
+- [MS packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/MS%20Packet%20Reference.md) is the in-character message.
+- [CT packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#CT-Server) is the OOC message.
+- [MC packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#MC) is the Music Change packet and is responsible for playing music (use "Client as Receiver" version of the packet)
+- [BN packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#BN) is the Background Name packet and is responsbile for changing the background.
+- [HP packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#hp) updates the penalty bar values.
+- [RT packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#rt) is the witness testimony, cross examination, or an arbitrary animation with a noise. It is unaffected by the message queue and shows up instantly.
+- [JD packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#jd) decides if the judge controls (WTCE, penalty + - buttons in the theme) should appear or hide for the client.
+- GM packet is the DRO GameMode packet. It decides what theme gamemode to set (Prefer using /subtheme)
+- [ST packet](https://github.com/AttorneyOnline/docs/blob/master/docs/Development/network/Packet%20Reference.md#ST) is the SubTheme packet. It decides what subtheme of the theme to use. (Prefer using /subtheme)
 
 Note that packets do not change state - this means that if you use BN, it will ONLY apply the
 Background for the clients that received that packet until something else sends it again, while
 /bg actually changes the area's Background persistantly meaning anyone new entering this area will
 see the new background as well. This means you should prefer to use /commands unless you want to
 send an IC message or don't want to modify the area details!
-
 
 ## Variables
 
@@ -161,7 +162,7 @@ Ordering comparisons (`==` equal to, `!=` not equal to, `<` less than, `>` great
 kind - two numbers, or two strings. Comparing a number to a string stops the
 script with an error.
 
-## Putting live values in your text
+## Variables in Text
 
 `<!name>` anywhere in a packet or command drops in the current value:
 
@@ -174,126 +175,157 @@ CT#narrator#Only <!count> more minutes!%
 You can also drop live state straight in - see below - so `<!players>` works
 too.
 
-## Reading the server's state
+## Reading Server Values
 
-`get` reads a value and stores it in a variable. These special names are
-always available:
-
-| Name                  | What you get                              |
-| --------------------- | ----------------------------------------- |
-| `players`             | How many people are in the area           |
-| `max_players`         | The area's player cap                     |
-| `hp_def`              | The defense HP bar value                  |
-| `hp_pro`              | The prosecution HP bar value              |
-| `char_count`          | How many characters are on the server     |
+`get` reaches into the server, reads one value, and stashes it in a variable.
+From then on you can use that variable anywhere in the script:
 
 ```
 get total players
 CT#narrator#There are <!total> players here!%
 ```
 
-### Digging deeper with paths
+A few handy values are always available without any setup:
 
-`get` can also walk into the server's state with a **path**:
+| Name          | What it is                                      |
+| ------------- | ----------------------------------------------- |
+| `players`     | How many people are in The area right now       |
+| `max_players` | The most people The area allows                 |
+| `hp_def`      | The defense side's penalty bar                  |
+| `hp_pro`      | The prosecution side's penalty bar              |
+| `char_count`  | How many characters the server has              |
 
-| Path                      | What you get                                  |
-| ------------------------- | --------------------------------------------- |
-| `clients.count`           | Number of real clients in the area            |
-| `client[i].<field>`       | Something about the i-th person in the area   |
-| `afk.count`               | Number of AFK clients in the area             |
-| `afk[i].<field>`          | Something about the i-th AFK client           |
-| `timer[i].<field>`        | Something about the i-th timer                |
-| `evidence.count`          | Number of evidence items in the area          |
-| `evidence[i].<field>`     | Something about the i-th evidence item        |
-| `links.count`             | Number of area links                          |
-| `links[i].<field>`        | Something about the i-th area link            |
-| `char[<name>].<key>`      | A saved value for a character (see below)     |
-| `area.<field>`            | Something about the current area              |
-| `hub.<field>`             | Something about the current hub               |
+### Paths
 
-`client[0]` is the first person in the area, `client[1]` the second, and so on
-- in the same order `/getarea` lists them. You can even use a custom variable as the
-index: `client[i]`, `client[i+1]`.
+Everything else needs a **path** - one long name that points at an exact thing.
+A path is an address: *what kind of thing*, *which one*, and *what you want to
+read off it*:
 
 ```
-get first client[0].showname
-CT#narrator#First in the room: <!first>%
+client[0].showname
+│       │     └─ what you want to read
+│       └─ which one (0 = the first)
+└─ what kind of thing
 ```
 
-**Timers.** Timer numbers are the same ones `/timer` shows: `timer[0]` is the
-hub-wide timer, `timer[1]` through `timer[20]` are the area's own.
+Here's the whole menu. Each row is its own section just below.
 
-| Field           | What you get                                  |
-| --------------- | --------------------------------------------- |
-| `remaining_ms`  | Millis left on the timer (0 if it isn't set)  |
-| `static_ms`     | The time the timer was set to (0 if unset)    |
-| `set`           | `1` if the timer is set/shown, else `0`       |
-| `started`       | `1` if the timer is running, else `0`         |
+| Path                     | What it points at                             | Section         |
+| ------------------------ | --------------------------------------------- | --------------- |
+| `clients.count`          | How many people are in The area               | Clients         |
+| `client[i].<field>`      | One person in The area                        | Clients         |
+| `afk[i].<field>`         | A person who's marked AFK                     | Clients         |
+| `timer[i].<field>`       | A countdown timer                             | Timers          |
+| `evidence[i].<field>`    | A piece of evidence                           | Evidence        |
+| `links[i].<field>`       | A door to another area                        | Area links      |
+| `area.<field>`           | The area you're in                            | The area        |
+| `hub.<field>`            | The hub your area is in                       | The hub         |
+| `char[<name>].<key>`     | A character's saved data                      | Character data  |
+
+Two small rules make paths easy to read:
+
+- **Counting starts at zero.** The first person is `client[0]`, the second is
+  `client[1]`, the third `client[2]`... It's the same for evidence, links,
+  timers and AFK people.
+- **`.count` gives a total.** Swap the `[i]` for `.count` to get how many
+  there are: `clients.count`, `evidence.count`, `links.count`, `afk.count`.
+
+The number in the brackets doesn't have to be typed out - it can be a variable,
+so loops can walk through everyone (`client[i]`, `client[i+1]`). Ask for a path
+or field that doesn't exist and the script stops with an error, so the lists
+below are the whole menu.
+
+### Clients
+
+`client[0]` is the first person The area lists, `client[1]` the second, and so
+on. `afk[i]` works the same way but only for people marked AFK (with `/afk`);
+both read the same fields.
+
+What you can read off a person:
+
+| Field            | What it is                                          |
+| ---------------- | --------------------------------------------------- |
+| `id`             | The player's user number (the `[User]` number)      |
+| `name`           | Their OOC name                                      |
+| `char_name`      | The name of the character they're playing           |
+| `char_id`        | Their character's number (see `/charids`)           |
+| `char_folder`    | Their character's folder name                       |
+| `showname`       | The name above their head (falls back to their character's name) |
+| `pos`            | The position they're standing in                    |
+| `pair`           | The character they're paired with (`-1` = not paired) |
+| `iniswap`        | The character they look like via `/iniswap` (empty = normal) |
+| `hidden_in`      | The evidence they're hiding in (empty = not hiding) |
+| `listen_pos`     | Positions they're listening to (empty = the whole area) |
+| `last_move_time` | A timestamp of when they last moved or spoke        |
+| `subtheme`       | The subtheme they're forced to see (empty = normal) |
+| `time_of_day`    | The time of day they're forced to see (empty = normal) |
+| `char_url`       | The link shown on their character                   |
+| `remote_listen`  | Their remote listening: `0` none, `1` IC only, `2` OOC, `3` everything |
+
+The flags below come back as `1` (yes) or `0` (no):
+
+| Flag         | `1` means...                  |
+| ------------ | ----------------------------- |
+| `is_cm`      | They're a CM of The area      |
+| `is_gm`      | They're a GM of the hub       |
+| `is_owner`   | They're a CM or GM            |
+| `is_afk`     | They're marked AFK            |
+| `hidden`     | They're hidden                |
+| `blinded`    | They're blinded               |
+| `sneaking`   | They're sneaking              |
+| `frozen`     | They're frozen                |
 
 ```
-get left timer[3].remaining_ms
-if left == 0 timeout
-CT#narrator#<left> ms left on the deliberation timer!%
-```
-
-**What you can read from a person:** `id`, `char_id`, `char_name`, `showname`,
-`name` (their OOC name), `char_folder`, `pos`, `pair`, `iniswap`,
-`last_move_time` (ms since their last action), `remote_listen`, `subtheme`,
-`time_of_day`, `char_url`, `hidden_in` (the evidence index they're hiding in,
-empty if not hiding), `listen_pos` (space-separated positions they're listening
-to, empty while listening normally), and the yes/no flags `is_cm`, `is_gm`,
-`is_owner`, `is_afk`, `hidden`, `blinded`, `sneaking`, `frozen`.
-Moderator-only details like IP/HDID hashes and `is_mod` are not exposed to
-scripts.
-
-```
-if client[i].hidden eq 1 skip
+if client[i].hidden == 1 skip
 get showname client[i].showname
 concat list showname ", "
 ```
 
-**What you can read from the area:**
+For safety, mod-only details such as IP/HDID hashes and `is_mod` are never
+given to scripts.
 
-- Identity and description: `name`, `id`, `abbreviation`, `desc`, `status`, `doc`
-- Background and position: `background`, `background_dark`, `background_suffix`,
-  `overlay`, `pos_lock` (space-separated positions, empty when unlocked),
-  `bg_lock`, `overlay_lock`, `pos_dark`, `desc_dark`, `dark`
-- Permissions and behavior: `can_cm`, `locking_allowed`, `iniswap_allowed`,
-  `showname_changes_allowed`, `shouts_allowed`, `non_int_pres_only`,
-  `evidence_mod`, `blankposting_allowed`, `blankposting_forced`,
-  `ooc_actions_enabled`, `present_reveals_evidence`, `passing_msg`,
-  `can_whisper`, `can_wtce`, `can_change_status`, `can_spectate`, `can_getarea`,
-  `use_backgrounds_yaml`, `hide_clients`, `force_sneak`, `locked`, `muted`,
-  `password`, `hidden`, `max_players`, `hp_def`, `hp_pro`, `move_delay`,
-  `msg_delay`, `medieval_mode`
-- Music: `music`, `music_autoplay`, `music_looping`, `music_effects`,
-  `music_ref`, `replace_music`, `client_music`, `ambience`, `can_dj`, `jukebox`,
-  `music_locked`
-- Minigames: `can_battle`, `auto_pair`, `auto_pair_max`, `auto_pair_cycle`,
-  `can_cross_swords`, `can_scrum_debate`, `can_panic_talk_action`, and the
-  matching `*_song_start`, `*_song_end`, `*_song_concede` tracks
+### Timers
 
-The yes/no flags above return `1` or `0`.
+`timer[0]` is the hub-wide timer; `timer[1]` through `timer[20]` are The area's
+own - the same numbers `/timer` shows.
 
-**What you can read from the hub:** `name`, `id`, `abbreviation`, `subtheme`,
-`time_of_day`, `doc` (its description), `info` (same as `doc`), `char_count`,
-`char_list_ref`, `music_ref`, `move_delay`, `current_areas` (how many areas the
-hub has), and the yes/no flags `arup_enabled`, `hide_clients`, `can_gm`,
-`single_cm`, `replace_music`, `client_music`, `can_spectate`, `can_getareas`,
-`passing_msg`, `autokick_to_latest_area`, plus `max_areas`.
+| Field          | What it is                                     |
+| -------------- | ---------------------------------------------- |
+| `remaining_ms` | Milliseconds left (0 if it isn't running)      |
+| `static_ms`    | The time it was set to (0 if it isn't set)     |
+| `set`          | `1` if a timer is set/shown, else `0`          |
+| `started`      | `1` if it's counting down, else `0`            |
 
-**What you can read from an evidence item.** `evidence[i]` is the i-th piece
-of evidence, 0-based, in the order the area lists it. Fields: `name`, `desc`,
-`image`, `pos` (the positions it shows in), `show_in_dark` (0 = never in dark
-areas, 1 = always, 2 = only in dark areas), `hiding` (the showname of whoever
-is hiding inside, empty if empty), and the yes/no flags `can_hide_in`,
-`can_take`, `editable`.
+```
+get left timer[3].remaining_ms
+if left == 0 timeout
+CT#narrator#<!left> ms left on the deliberation timer!%
+return
+label timeout
+CT#narrator#Time's up!%
+```
+
+### Evidence
+
+`evidence[i]` is the i-th piece of evidence, in the order The area lists it.
+
+| Field          | What it is                                          |
+| -------------- | --------------------------------------------------- |
+| `name`         | The evidence's name                                 |
+| `desc`         | Its description                                     |
+| `image`        | Its image file                                      |
+| `pos`          | The positions it shows in                           |
+| `show_in_dark` | `0` = never in dark areas, `1` = always, `2` = dark areas only |
+| `hiding`       | The showname of whoever is hidden inside (empty if nobody) |
+| `can_hide_in`  | `1` if people can hide in it                        |
+| `can_take`     | `1` if it can be taken                              |
+| `editable`     | `1` if players can edit it                          |
 
 ```
 get count evidence.count
 set i 0
 label loop
-if i ge count done
+if i >= count done
 get item evidence[i].name
 CT#narrator#Evidence <!i>: <!item>%
 set i i+1
@@ -301,20 +333,29 @@ goto loop
 label done
 ```
 
-**What you can read from an area link.** A link is a one-way connection to
-another area. `links[i]` is 0-based, in the order the links were created.
-Fields: `target` (the area ID the link leads to), `target_pos` (the position
-you arrive in), `evidence` (space-separated evidence IDs you must have to pass
-through), `password`, and the yes/no flags `locked`, `hidden`, `can_peek`.
+### Area links
+
+A link is a one-way door to another area. `links[i]` walks through them in the
+order they were made.
+
+| Field         | What it is                                       |
+| ------------- | ------------------------------------------------ |
+| `target`      | The area number the link leads to                |
+| `target_pos`  | The position you arrive in                       |
+| `evidence`    | Evidence numbers you must have to pass (space-separated) |
+| `password`    | The password to pass (empty = none)              |
+| `locked`      | `1` if the link is locked                        |
+| `hidden`      | `1` if the link is hidden                        |
+| `can_peek`    | `1` if you can peek through it                   |
 
 ```
 get count links.count
 set i 0
 label loop
-if i ge count done
+if i >= count done
 get target links[i].target
 get locked links[i].locked
-if locked eq 1 blocked
+if locked == 1 blocked
 CT#narrator#To area <!target>: open%
 goto next
 label blocked
@@ -325,9 +366,130 @@ goto loop
 label done
 ```
 
-Only these fields exist - scripts can't reach into anything else on the server.
-If you ask for a path or field that doesn't exist, the script stops with an
-error.
+### The area
+
+The area you're in is spelled `area` in paths - `area.<field>`. You can read
+its name and looks, what people are allowed to do, the music, and the
+minigames.
+
+What The area is called and how it looks:
+
+| Field               | What it is                                        |
+| ------------------- | ------------------------------------------------- |
+| `name`              | The area's name                                   |
+| `id`                | The area's number                                 |
+| `abbreviation`      | The area's short code                             |
+| `desc`              | Its description                                   |
+| `status`            | Its status tag                                    |
+| `doc`               | Its info page                                     |
+| `background`        | The current background                            |
+| `background_dark`   | The background used in dark mode                  |
+| `background_suffix` | A suffix added to every background name           |
+| `overlay`           | The overlay image                                 |
+| `pos_lock`          | Allowed positions, space-separated (empty = any)  |
+| `bg_lock`           | `1` if only CMs can change the background         |
+| `overlay_lock`      | `1` if only CMs can change the overlay            |
+| `pos_dark`          | Positions allowed in dark mode                    |
+| `desc_dark`         | The description shown in dark mode                |
+| `dark`              | `1` if The area is in dark mode                   |
+
+What people are allowed to do (flags are `1` for yes, `0` for no):
+
+| Field                        | `1` means...                                    |
+| ---------------------------- | ----------------------------------------------- |
+| `can_cm`                     | Players can become CM here                      |
+| `locking_allowed`            | CMs can lock/unlock links                       |
+| `iniswap_allowed`            | `/iniswap` is allowed                           |
+| `showname_changes_allowed`   | Players can change their showname               |
+| `shouts_allowed`             | Shouting is allowed                             |
+| `non_int_pres_only`          | Only non-interrupting presents are allowed      |
+| `evidence_mod`               | How evidence is shared (`FFA`, `CM`, `Mods`, `HiddenCM`) |
+| `blankposting_allowed`       | Blank posts are allowed                         |
+| `blankposting_forced`        | Every IC post must be blank                     |
+| `ooc_actions_enabled`        | OOC actions are on                              |
+| `present_reveals_evidence`   | Presenting shows the evidence to everyone       |
+| `passing_msg`                | `/passing` is enabled                           |
+| `can_whisper`                | Whispers are allowed                            |
+| `can_wtce`                   | Witness testimony / cross-exam is allowed       |
+| `can_change_status`          | Players can change their status                 |
+| `can_spectate`               | Spectating is allowed                           |
+| `can_getarea`                | Players can see The area list                   |
+| `use_backgrounds_yaml`       | Backgrounds come from `backgrounds.yaml`        |
+| `hide_clients`               | The player list is hidden                       |
+| `force_sneak`                | Everyone appears hidden                         |
+| `locked`                     | The area is locked (no one can enter)           |
+| `muted`                      | IC chat is muted                                |
+| `password`                   | The password to enter (empty = none)            |
+| `hidden`                     | The area is hidden from The area list           |
+| `max_players`                | The most people allowed                         |
+| `hp_def`                     | The defense penalty bar                         |
+| `hp_pro`                     | The prosecution penalty bar                     |
+| `move_delay`                 | Extra delay between moves, in milliseconds      |
+| `msg_delay`                  | Delay between IC messages, in milliseconds      |
+| `medieval_mode`              | Medieval mode is on                             |
+
+The music:
+
+| Field            | What it is                                       |
+| ---------------- | ------------------------------------------------ |
+| `music`          | The current song                                 |
+| `music_autoplay` | `1` if the song autoplays                        |
+| `music_looping`  | `1` if the song loops                            |
+| `music_effects`  | The current sound effect                         |
+| `music_ref`      | Which music list The area uses                   |
+| `replace_music`  | `1` if The area's music overrides the hub's      |
+| `client_music`   | `1` if players can play their own music          |
+| `ambience`       | The ambience track                               |
+| `can_dj`         | `1` if players can DJ                            |
+| `jukebox`        | `1` if the jukebox is on                         |
+| `music_locked`   | `1` if the music is locked                       |
+
+Minigames:
+
+| Field                                                       | What it is                                          |
+| ----------------------------------------------------------- | --------------------------------------------------- |
+| `can_battle`                                                | `1` if the battle minigame is allowed               |
+| `auto_pair`                                                 | `1` if auto-pairing is on                           |
+| `auto_pair_max`                                             | The longest auto-pair allowed                       |
+| `auto_pair_cycle`                                           | `1` if pairs cycle through positions                |
+| `can_cross_swords`                                          | `1` if the cross-swords minigame is allowed         |
+| `can_scrum_debate`                                          | `1` if the scrum-debate minigame is allowed         |
+| `can_panic_talk_action`                                     | `1` if the panic-talk-action minigame is allowed    |
+| `cross_swords_song_start` / `_song_end` / `_song_concede`   | Music when that minigame starts / ends / is conceded |
+| `scrum_debate_song_start` / `_song_end` / `_song_concede`   | Same, for scrum debate                               |
+| `panic_talk_action_song_start` / `_song_end` / `_song_concede` | Same, for panic talk action                       |
+
+### The hub
+
+The hub is the group of areas your area belongs to - it decides the shared
+character list, music list and movement delay. It's spelled `hub` in paths -
+`hub.<field>`.
+
+| Field                   | What it is                                         |
+| ----------------------- | -------------------------------------------------- |
+| `name`                  | The hub's name                                     |
+| `id`                    | The hub's number                                   |
+| `abbreviation`          | The hub's short code                               |
+| `subtheme`              | The subtheme applied to every area                 |
+| `time_of_day`           | The time of day applied to every area              |
+| `doc`                   | The hub's description                              |
+| `info`                  | Same as `doc`                                      |
+| `char_count`            | How many characters the hub has                    |
+| `char_list_ref`         | The character list file it uses                    |
+| `music_ref`             | The music list it uses                             |
+| `move_delay`            | Delay between moves for every area, in milliseconds |
+| `current_areas`         | How many areas the hub has                         |
+| `max_areas`             | The most areas allowed                             |
+| `arup_enabled`          | `1` if the player-count announcement is on         |
+| `can_gm`                | `1` if players can become GM                       |
+| `single_cm`             | `1` if only one CM per area is allowed             |
+| `hide_clients`          | `1` if player lists are hidden                     |
+| `replace_music`         | `1` if server music overrides hub music            |
+| `client_music`          | `1` if players can play their own music            |
+| `can_spectate`          | `1` if spectating is allowed                       |
+| `can_getareas`          | `1` if players can see The area list               |
+| `passing_msg`           | `1` if `/passing` is enabled                       |
+| `autokick_to_latest_area` | `1` if players are sent back to their last area  |
 
 ## Character data: remembering things between demos
 
@@ -416,14 +578,14 @@ The bounds can be numbers, expressions, or variables. If `min` is bigger than
 `if` jumps to a label when a comparison is true:
 
 ```
-if total ge 5 full
-CT#narrator#Plenty of room!%
+if total >= 5 full
+CT#narrator#Plenty of area!%
 label full
 ```
 
-The comparisons are `eq` (equal), `ne` (not equal), `lt` (less than), `gt`
-(greater than), `le` (less or equal), `ge` (greater or equal). The usual
-symbols work too: `==`, `!=`, `<`, `>`, `<=`, `>=`.
+The comparisons use the usual symbols: `==` equal, `!=` not equal, `<` less
+than, `>` greater than, `<=` less or equal, `>=` greater or equal. (The words
+`eq`, `ne`, `lt`, `gt`, `le`, `ge` mean the same thing and also work.)
 
 ```
 if count == 0 done
@@ -447,6 +609,7 @@ set count count-1
 if count > 0 loop
 CT#narrator#Blastoff!%
 ```
+
 turns into: 5! 4! 3! 2! 1! Blastoff!
 
 `goto` remembers where it came from, and `return` jumps back. Use that for a
@@ -468,31 +631,6 @@ can use a bare `return` at the end of a script to stop it early. Labels are
 scoped to the current script, and jumping to a label that doesn't exist stops
 the script.
 
-## When things go wrong
-
-- Any error prints `[Demo] [ERROR] ...` to the area and stops the script. The
-  area's HP bars and background are restored before it stops.
-- A script can't run forever. After 100,000 steps it stops on its own
-  (configurable in `config.yaml` as `demo_max_steps`) - so an accidental
-  infinite loop can't stall the server.
-- `/stop_demo` (GMs and mods) stops playback at any time, and `/demo` with no
-  argument does too.
-
-## A couple of extras
-
-**Chaining.** A script can run another demo:
-
-```
-/demo 3%
-```
-
-That *replaces* the current script with demo 3 - labels start over. It's a
-jump, not a subroutine; use `goto`/`return` within the same demo if you want to come back.
-
-**Escaping.** If your text ever needs a literal `#`, `&`, `%`, or `$`, write
-them as `<num>`, `<and>`, `<percent>`, `<dollar>`. Use `<percent>` if you need
-a `%` inside a quoted value.
-
 ## Timers
 
 Every area has 21 countdown timers: `0` is hub-wide, `1` through `20` belong to
@@ -512,7 +650,7 @@ Your script reads timers through the live paths from the table above:
 ```
 get left timer[3].remaining_ms
 if left == 0 timeout
-CT#narrator#<left> ms left on the deliberation timer!%
+CT#narrator#<!left> ms left on the deliberation timer!%
 ```
 
 ### Run a script when the timer expires
@@ -534,6 +672,7 @@ These lines are ordinary OOC commands, so a demo can arm a timer too - put
 through the area's system executor (the same headless client that runs demos),
 so they fire even with no CM/GM online. A demo started this way shares the
 area's variables with everything else.
+
 
 ## Triggers
 
@@ -578,10 +717,49 @@ CT#narrator#Welcome to the area, <!trigger_showname>!%
 The values stay until the next trigger fires (or a script overwrites them), so
 a demo has time to pick them up.
 
-**One shared state.** Demos, trigger commands and timer-expiry commands all run
-in the same area and share `area.variables`. A demo can leave a flag behind for
-a trigger to check, and a trigger's demo can set things up for a timer expiry
-that comes later.
+**Everything shares the same variables.** A demo, a trigger's command and a
+timer's command all run in the same room and read and write the same
+variables. So one script can write a note that a later script reads. For
+example, a trigger starts /demo 2, which sets:
+
+```
+set door_open 1
+```
+
+When the timer later runs its /demo 1 command, that script can check the note:
+
+```
+if door_open == 1 open_the_door
+```
+
+The note is still there even though the demo that wrote it has finished.
+
+## When things go wrong
+
+- Any error prints `[Demo] [ERROR] ...` to the area and stops the script. The
+  area's HP bars and background are restored before it stops.
+- A script can't run forever. After 100,000 steps it stops on its own
+  (configurable in `config.yaml` as `demo_max_steps`) - so an accidental
+  infinite loop can't stall the server.
+- `/stop_demo` (GMs and mods) stops playback at any time, and `/demo` with no
+  argument does too.
+
+## A couple of extras
+
+**Chaining.** A script can run another demo:
+
+```
+/demo 3%
+```
+
+The current script stops, and demo 3 starts from the top as if you'd just run
+it with `/demo 3`. Anything the current script set up (like labels or a place
+to `return` to) is gone - you can't come back to it. If you need to hop around
+and come back, use `goto` and `return` inside the *same* demo instead.
+
+**Escaping.** If your text ever needs a literal `#`, `&`, `%`, or `$`, write
+them as `<num>`, `<and>`, `<percent>`, `<dollar>`. Use `<percent>` if you need
+a `%` inside a quoted value.
 
 ## Example: list everyone present
 
@@ -590,8 +768,8 @@ set i 0
 get total clients.count
 set list ""
 label loop
-if i ge total done
-if client[i].hidden eq 1 skip
+if i >= total done
+if client[i].hidden == 1 skip
 get showname client[i].showname
 concat list showname ", "
 label skip

--- a/server/area.py
+++ b/server/area.py
@@ -3,6 +3,9 @@ from server import commands
 from server.evidence import EvidenceList
 from server.exceptions import ClientError, AreaError, ArgumentError, ServerError
 from server.constants import MusicEffect, ReportCardReason, derelative, censor
+from server.timer import Timer
+from server.script_runner import ScriptRunner, parse_demo_description
+from server.remote_client import RemoteClient
 
 from collections import OrderedDict
 
@@ -14,91 +17,12 @@ import json
 
 import oyaml as yaml  # ordered yaml
 import os
-import datetime
 import logging
-import traceback
 
 logger = logging.getLogger("area")
 
 
 class Area:
-    class Timer:
-        """Represents a single instance of a timer in the area."""
-
-        def __init__(
-            self,
-            _id,
-            Set=False,
-            started=False,
-            static=None,
-            target=None,
-            area=None,
-            caller=None,
-        ):
-            self.id = _id
-            self.set = Set
-            self.started = started
-            self.static = static
-            self.target = target
-            self.area = area
-            self.caller = caller
-            self.schedule = None
-            self.commands = []
-            self.format = "hh:mm:ss.zzz"
-            self.interval = 16
-
-        def timer_expired(self):
-            if self.schedule:
-                self.schedule.cancel()
-            # Either the area or the hub was destroyed at some point
-            if self.area is None or self is None:
-                return
-
-            self.static = datetime.timedelta(0)
-            self.started = False
-
-            self.area.broadcast_ooc(f"Timer {self.id+1} has expired.")
-            self.call_commands()
-
-        def call_commands(self):
-            if self.caller is None:
-                return
-            if self.area is None or self is None:
-                return
-            if self.caller not in self.area.owners:
-                return
-            # We clear out the commands as we call them in order one by one
-            while len(self.commands) > 0:
-                # Take the first command in the list and run it
-                cmd = self.commands.pop(0)
-                args = cmd.split(" ")
-                cmd = args.pop(0).lower()
-                arg = ""
-                if len(args) > 0:
-                    arg = " ".join(args)[:1024]
-                try:
-                    old_area = self.caller.area
-                    old_hub = self.caller.area.area_manager
-                    self.caller.area = self.area
-                    commands.call(self.caller, cmd, arg)
-                    if old_area and old_area in old_hub.areas:
-                        self.caller.area = old_area
-                except (ClientError, AreaError, ArgumentError, ServerError) as ex:
-                    self.caller.send_ooc(f"[Timer {self.id}] {ex}")
-                    # Command execution critically failed somewhere. Clear out all commands so the timer doesn't screw with us.
-                    self.commands.clear()
-                    # Even tho self.commands.clear() is going to break us out of the while loop, manually return anyway just to be safe.
-                    return
-                except Exception as ex:
-                    self.caller.send_ooc(
-                        f"[Timer {self.id}] An internal error occurred: {ex}. Please inform the staff of the server about the issue."
-                    )
-                    logger.error("Exception while running a command")
-                    # Command execution critically failed somewhere. Clear out all commands so the timer doesn't screw with us.
-                    self.commands.clear()
-                    # Even tho self.commands.clear() is going to break us out of the while loop, manually return anyway just to be safe.
-                    return
-
     """Represents a single instance of an area."""
 
     def __init__(self, area_manager, name):
@@ -257,14 +181,14 @@ class Area:
         self.links = {}
 
         # Timers ID 1 thru 20, (indexes 0 to 19 in area), timer ID 0 is reserved for hubs.
-        self.timers = [self.Timer(x) for x in range(20)]
+        self.timers = [Timer(x, area=self) for x in range(20)]
 
-        # Demo stuff
-        self.demo = []
-        self.demo_schedule = None
+        # Demo playback is driven by a ScriptRunner bound to this area's
+        # system executor client (see get_script_client).
+        self.demo_runner = None
+        self._script_client = None
 
         # Commands to call when certain triggers are fulfilled.
-        # #Requires at least 1 area owner to exist to determine permission.
         self.triggers = {
             "join": "",  # User joins the area.
             "leave": "",  # User leaves the area.
@@ -343,24 +267,35 @@ class Area:
         return bg + self.background_suffix
 
     def trigger(self, trig, target):
-        """Call the trigger's associated command."""
+        """Call the trigger's associated command through the system executor."""
+        if isinstance(target, RemoteClient):
+            return
         if target.hidden:
             return
-
-        if len(self.owners) <= 0:
-            return
-
         arg = self.triggers[trig]
         if arg == "":
             return
+        self._run_trigger_command(arg, target)
 
-        # Sort through all the owners, with GMs coming first and CMs coming second
-        sorted_owners = list(self._owners) + list(self.area_manager.owners)
+    def trigger_evidence(self, evi, trig, target):
+        """Call an evidence item's trigger (e.g. 'present') for a target."""
+        if isinstance(target, RemoteClient):
+            return
+        if target.hidden:
+            return
+        arg = (evi.triggers or {}).get(trig, "")
+        if arg == "":
+            return
+        self._run_trigger_command(arg, target)
 
-        # Pick the owner with highest permission - game master, if one exists.
-        # This permission system may be out of wack, but it *should* be good for now
-        owner = sorted_owners[0]
+    def _run_trigger_command(self, arg, target):
+        """
+        Run a trigger command through the area's system executor client.
 
+        The executor is a headless participant, so no real player's state is
+        hijacked and the trigger works regardless of which (if any) owners are
+        currently online or in the area.
+        """
         arg = (
             arg.replace("<cid>", str(target.id))
             .replace("<showname>", target.showname)
@@ -368,22 +303,37 @@ class Area:
         )
         args = arg.split(" ")
         cmd = args.pop(0).lower()
-        if len(args) > 0:
-            arg = " ".join(args)[:1024]
-        try:
-            old_area = owner.area
-            old_hub = owner.area.area_manager
-            owner.area = self
-            commands.call(owner, cmd, arg)
-            if old_area and old_area in old_hub.areas:
-                owner.area = old_area
-        except (ClientError, AreaError, ArgumentError, ServerError) as ex:
-            owner.send_ooc(f"[Area {self.id}] {ex}")
-        except Exception as ex:
-            owner.send_ooc(
-                f"[Area {self.id}] An internal error occurred: {ex}. Please inform the staff of the server about the issue."
+        arg = " ".join(args)[:1024] if args else ""
+        executor = self.get_script_client()
+        executor.execute(cmd, arg)
+        for msg in executor.output:
+            if msg.startswith("[ERROR]"):
+                self.broadcast_ooc(f"[Area {self.id}] {msg}")
+
+    def get_script_client(self):
+        """
+        Get (creating if necessary) the system executor client for this area.
+
+        The executor joins the area as a headless participant, so commands
+        executed on it (`client.area`, `client.area.area_manager`,
+        `area.owners`, `@mod_only` gates via `is_gm`) behave as if a real
+        GM ran them -- without depending on one being online. It is not a
+        mod: pure-mod commands are denied.
+
+        It is added to the hub's GM owner set directly (not via
+        `add_owner`, which broadcasts and hides the client) because many
+        command bodies check `client.area.area_manager.owners` themselves
+        rather than going through the `@mod_only` decorator.
+        """
+        if self._script_client is None:
+            from server.remote_client import RemoteClient
+
+            self._script_client = RemoteClient(
+                self.server, is_mod=False, name="[SCRIPT]", is_gm=True
             )
-            logger.error("Exception while running a command")
+            self._script_client.join_area(self)
+            self.area_manager.owners.add(self._script_client)
+        return self._script_client
 
     def abbreviate(self):
         """Abbreviate our name."""
@@ -825,7 +775,7 @@ class Area:
                 client.send_ooc(
                     "You can only be a CM of a single area in this hub.")
         # Trigger this routine only if a non-privileged client left the area, and there are no GMs in this hub.
-        if self.locking_allowed and len(self._owners) <= 0 and len(self.area_manager.owners) <= 0:
+        if self.locking_allowed and len(self._owners) <= 0 and len(self.area_manager.real_owners()) <= 0:
             # Since anyone can lock/unlock, unlock if we were the last client in this area and it was locked.
             if len(self.clients) - 1 <= 0:
                 if self.locked:
@@ -1553,6 +1503,8 @@ class Area:
         if (self.can_getarea and not self.dark) or special_allowed:
             for c in self.clients:
                 if c == target:
+                    continue
+                if isinstance(c, RemoteClient):
                     continue
                 if c.hidden and not special_allowed:
                     continue
@@ -2410,102 +2362,71 @@ class Area:
                 0,
             )
 
-    def play_demo(self, client):
-        if self.demo_schedule:
-            self.demo_schedule.cancel()
-        if len(self.demo) <= 0:
-            self.stop_demo()
-            return
-        if not (client in self.owners):
-            client.send_ooc(
-                f"[Demo] Playback stopped due to you having insufficient permissions! (Not CM/GM anymore)")
-            self.stop_demo()
-            return
+    def play_demo(self, client, evidence):
+        """
+        Start (or chain into) demo playback from an evidence item's description.
 
-        packet = self.demo.pop(0)
-        header = packet[0]
-        args = packet[1:]
-        # It's a wait packet
-        if header == "wait":
-            secs = float(args[0]) / 1000
-            self.demo_schedule = asyncio.get_running_loop().call_later(
-                secs, lambda: self.play_demo(client)
+        `client` is the requesting client (a player or the system executor); the
+        actual playback runs through this area's system executor client, so it
+        keeps working even if the requester disconnects or loses permissions.
+        """
+        instructions = parse_demo_description(evidence.desc)
+        if not instructions:
+            msg = (
+                f"[Demo] Evidence '{evidence.name}' has no demo instructions: "
+                "lines must end with '%' and use known packets/commands."
             )
+            self.broadcast_ooc(msg)
             return
-        if header.startswith("/"):  # It's a command call
-            # TODO: make this into a global function so commands can be called from anywhere in code...
-            cmd = header[1:].lower()
-            arg = ""
-            if len(args) > 0:
-                arg = " ".join(args)[:1024]
-            try:
-                called_function = f"ooc_cmd_{cmd}"
-                if len(client.server.command_aliases) > 0 and not hasattr(
-                    commands, called_function
-                ):
-                    if cmd in client.server.command_aliases:
-                        called_function = (
-                            f"ooc_cmd_{client.server.command_aliases[cmd]}"
-                        )
-                if not hasattr(commands, called_function):
-                    client.send_ooc(
-                        f"[Demo] Invalid command: {cmd}. Use /help to find up-to-date commands."
-                    )
-                    self.stop_demo()
-                    return
-                getattr(commands, called_function)(client, arg)
-                # Switching to another demo (can't have multiple concurrent demos running)
-                if cmd == "demo":
-                    return
-            except (ClientError, AreaError, ArgumentError, ServerError) as ex:
-                client.send_ooc(f"[Demo] {ex}")
-                self.stop_demo()
-                return
-            except Exception as ex:
-                client.send_ooc(
-                    f"[Demo] An internal error occurred: {ex}. Please inform the staff of the server about the issue."
-                )
-                logger.error("Exception while running a Demo command:")
-                traceback.print_exc()
-                print(ex)
-                self.stop_demo()
-                return
-        else:
-            area_list = [self]
-            if len(client.broadcast_list) > 0:
-                area_list = client.broadcast_list
-            # we probably shouldn't broadcast the area broadcast list with demos as it removes a level of control and granularity
-            # if len(self.broadcast_list) > 0:
-            #     area_list += self.broadcast_list
-            for area in area_list:
-                if header == "MS":
-                    # If we're on narration pos
-                    if args[5] == "":
-                        if area.last_ic_message is not None:
-                            # Set the pos to last message's pos
-                            args[5] = area.last_ic_message[5]
-                        else:
-                            # Set the pos to the 0th pos-lock
-                            if len(self.pos_lock) > 0:
-                                args[5] = self.pos_lock[0]
-                area.send_command(header, *args)
-        # Proceed to next demo line
-        self.play_demo(client)
+        self._warn_demo_out_of_range(client, evidence, instructions)
+        runner = self.demo_runner
+        if runner is None:
+            runner = ScriptRunner(self, self.get_script_client())
+            self.demo_runner = runner
+        runner.start(instructions)
 
     def stop_demo(self):
-        if self.demo_schedule:
-            self.demo_schedule.cancel()
-        self.demo.clear()
+        if self.demo_runner is not None:
+            self.demo_runner.stop()
 
-        # reset the packets the demo could have modified
+    def _warn_demo_out_of_range(self, client, evidence, instructions):
+        """
+        Warn a human caller about MS packets whose char id is out of range.
 
-        # Get defense HP bar
-        self.send_command("HP", 1, self.hp_def)
-        # Get prosecution HP bar
-        self.send_command("HP", 2, self.hp_pro)
-
-        # Send the background information
-        self.send_command("BN", self.background)
+        Clients silently drop MS packets whose char id isn't a valid index into
+        the server's character list, so a demo captured on a bigger server can
+        appear to do nothing here. Chained `/demo` calls (RemoteClient) have no
+        human caller and are skipped.
+        """
+        if client is None or isinstance(client, RemoteClient):
+            # No human caller to warn (executor-triggered demos, present/join
+            # triggers, chained /demo). Broadcast so GMs in the area see why
+            # the demo's IC content won't render.
+            target = None
+        else:
+            target = client
+        nchars = len(self.area_manager.char_list)
+        for kind, *rest in instructions:
+            if kind == "packet" and len(rest) >= 2 and rest[0] == "MS" and len(rest[1]) > 8:
+                try:
+                    cid = int(rest[1][8])
+                except (TypeError, ValueError):
+                    continue
+                if 0 <= cid < nchars:
+                    continue
+                # system character is a valid way to handle it.
+                if cid == -1:
+                    continue
+                noun = "character" if nchars == 1 else "characters"
+                msg = (
+                    f"[Demo] Warning: evidence '{evidence.name}' has an MS packet "
+                    f"with char id {cid}, which is out of range (this server only "
+                    f"has {nchars} {noun}). The message won't appear on clients."
+                )
+                if target is None:
+                    self.broadcast_ooc(msg)
+                else:
+                    target.send_ooc(msg)
 
     class JukeboxVote:
         """Represents a single vote cast for the jukebox."""

--- a/server/area.py
+++ b/server/area.py
@@ -317,22 +317,33 @@ class Area:
         The executor joins the area as a headless participant, so commands
         executed on it (`client.area`, `client.area.area_manager`,
         `area.owners`, `@mod_only` gates via `is_gm`) behave as if a real
-        GM ran them -- without depending on one being online. It is not a
+        owner ran them -- without depending on one being online. It is not a
         mod: pure-mod commands are denied.
 
-        It is added to the hub's GM owner set directly (not via
-        `add_owner`, which broadcasts and hides the client) because many
-        command bodies check `client.area.area_manager.owners` themselves
-        rather than going through the `@mod_only` decorator.
+        Its authority mirrors the hub's ownership model. In GM-capable hubs
+        (`can_gm`) it is added to the hub's GM owner set, so automation can
+        use GM commands (e.g. the hub-wide `/timer 0`). In claim-only hubs
+        (e.g. KFO Hub 0, where only areas can be claimed) it is added to the
+        area's CM owner set instead, so a CM-set automation script acts as an
+        area owner and can never escalate to GM power. It is added directly
+        (not via `add_owner`, which broadcasts and hides the client) because
+        many command bodies check the owner sets themselves rather than going
+        through the `@mod_only` decorator.
         """
         if self._script_client is None:
-            from server.remote_client import RemoteClient
-
-            self._script_client = RemoteClient(
-                self.server, is_mod=False, name="[SCRIPT]", is_gm=True
-            )
+            can_gm = self.area_manager.can_gm
+            self._script_client = RemoteClient(self.server, is_mod=False, name="[SCRIPT]", is_gm=can_gm)
+            self._script_client.is_automation = True
             self._script_client.join_area(self)
-            self.area_manager.owners.add(self._script_client)
+            if can_gm:
+                self.area_manager.owners.add(self._script_client)
+            else:
+                self._owners.add(self._script_client)
+        elif self._script_client.area is not self:
+            # A GM-level executor may have been moved to another area (e.g. by
+            # /area_kick). Pull it back to the area that owns it so the demo or
+            # trigger runs against the correct area.
+            self._script_client.join_area(self)
         return self._script_client
 
     def abbreviate(self):
@@ -775,7 +786,7 @@ class Area:
                 client.send_ooc(
                     "You can only be a CM of a single area in this hub.")
         # Trigger this routine only if a non-privileged client left the area, and there are no GMs in this hub.
-        if self.locking_allowed and len(self._owners) <= 0 and len(self.area_manager.real_owners()) <= 0:
+        if self.locking_allowed and len(self.real_cms()) <= 0 and len(self.area_manager.real_owners()) <= 0:
             # Since anyone can lock/unlock, unlock if we were the last client in this area and it was locked.
             if len(self.clients) - 1 <= 0:
                 if self.locked:
@@ -2010,13 +2021,21 @@ class Area:
         for client in self.clients:
             client.update_evidence_list()
 
+    def real_cms(self):
+        """
+        CMs that are real players, excluding system executors (RemoteClient).
+        The script executor may hold CM permission for command checks but must
+        not drive CM lifecycle events like area resets or CM listings.
+        """
+        return {o for o in self._owners if not isinstance(o, RemoteClient)}
+
     def get_owners(self):
         """
         Get a string of area's owners (CMs).
         :return: message
         """
         msg = ""
-        for i in self._owners:
+        for i in self.real_cms():
             msg += f"[{str(i.id)}] {i.showname}, "
         if len(msg) > 2:
             msg = msg[:-2]
@@ -2049,7 +2068,7 @@ class Area:
             client.broadcast_list.clear()
             client.send_ooc("Your broadcast list has been cleared.")
 
-        if self.area_manager.single_cm and len(self._owners) == 0:
+        if self.area_manager.single_cm and len(self.real_cms()) == 0:
             if self.locked:
                 self.unlock()
             if self.password != "":

--- a/server/area.py
+++ b/server/area.py
@@ -132,7 +132,7 @@ class Area:
         self.red_team = set()
         self.blue_team = set()
         # Clients who cast votes
-        self.votes_cast = set()      
+        self.votes_cast = set()
         # What percentage of valid voters needs to vote to force-end the minigame, rounded
         self.votes_percentage = 0.7
         # Minigame name
@@ -194,6 +194,9 @@ class Area:
             "leave": "",  # User leaves the area.
         }
 
+        # Mutable script variables for demo scripting (see docs/demo_scripting.md).
+        self.variables = {}
+
         # Battle system stuff
         self.can_battle = True
         self.battle_started = False
@@ -226,7 +229,7 @@ class Area:
 
         # list of areas to broadcast ic messages to
         self.broadcast_list = []
-        
+
         # doorman vars
         self.doorman_call_time = 0
 
@@ -239,8 +242,7 @@ class Area:
     def name(self, value):
         self._name = value.strip()
         while "<num>" in self._name or "<percent>" in self._name:
-            self._name = self._name.replace(
-                "<num>", "").replace("<percent>", "")
+            self._name = self._name.replace("<num>", "").replace("<percent>", "")
         self.abbreviation = self.abbreviate()
 
     @property
@@ -301,6 +303,11 @@ class Area:
             .replace("<showname>", target.showname)
             .replace("<char>", target.char_name)
         )
+        # Script context: a /demo run by this trigger can read who fired it
+        # (see docs/demo_scripting.md). Values persist until the next trigger.
+        self.variables["trigger_cid"] = target.id
+        self.variables["trigger_showname"] = target.showname
+        self.variables["trigger_char"] = target.char_name
         args = arg.split(" ")
         cmd = args.pop(0).lower()
         arg = " ".join(args)[:1024] if args else ""
@@ -526,14 +533,14 @@ class Area:
             self.pos_dark = area["pos_dark"]
         if "desc_dark" in area:
             self.desc_dark = area["desc_dark"]
-        if 'passing_msg' in area:
-            self.passing_msg = area['passing_msg']
-        if 'msg_delay' in area:
-            self.msg_delay = area['msg_delay']
-        if 'present_reveals_evidence' in area:
-            self.present_reveals_evidence = area['present_reveals_evidence']
-        if 'ooc_actions_enabled' in area:
-            self.ooc_actions_enabled = area['ooc_actions_enabled']
+        if "passing_msg" in area:
+            self.passing_msg = area["passing_msg"]
+        if "msg_delay" in area:
+            self.msg_delay = area["msg_delay"]
+        if "present_reveals_evidence" in area:
+            self.present_reveals_evidence = area["present_reveals_evidence"]
+        if "ooc_actions_enabled" in area:
+            self.ooc_actions_enabled = area["ooc_actions_enabled"]
 
         if "evidence" in area and len(area["evidence"]) > 0:
             self.evi_list.evidences.clear()
@@ -563,8 +570,7 @@ class Area:
                     evidence = value["evidence"]
                 if "password" in value:
                     password = value["password"]
-                self.link(key, locked, hidden, target_pos,
-                          can_peek, evidence, password)
+                self.link(key, locked, hidden, target_pos, can_peek, evidence, password)
 
         # Update the clients in that area
         if self.dark:
@@ -578,9 +584,7 @@ class Area:
         if self.music_autoplay:
             for client in self.clients:
                 if self.music != client.playing_audio[0]:
-                    client.send_command(
-                        "MC", self.music, -1, "", self.music_looping, 0, self.music_effects
-                    )
+                    client.send_command("MC", self.music, -1, "", self.music_looping, 0, self.music_effects)
 
         if "can_battle" in area:
             self.can_battle = area["can_battle"]
@@ -681,7 +685,7 @@ class Area:
             client.send_command(
                 "area_ambient",
                 # for compatibility with the KFO method, navigate out of sounds/ambience into sounds/music
-                "../music/"+self.ambience,
+                "../music/" + self.ambience,
             )
         else:
             # AO packet
@@ -694,8 +698,7 @@ class Area:
                     "",
                     1,
                     1,
-                    int(MusicEffect.FADE_OUT |
-                        MusicEffect.FADE_IN | MusicEffect.SYNC_POS),
+                    int(MusicEffect.FADE_OUT | MusicEffect.FADE_IN | MusicEffect.SYNC_POS),
                 )
 
     def new_client(self, client):
@@ -711,9 +714,7 @@ class Area:
         """Update the client with the relevant information about the area. Does not care if the client loaded in yet or not."""
         # Autoplay music
         if self.music_autoplay and self.music != client.playing_audio[0]:
-            client.send_command(
-                "MC", self.music, -1, "", self.music_looping, 0, self.music_effects
-            )
+            client.send_command("MC", self.music, -1, "", self.music_looping, 0, self.music_effects)
 
         # Update the timers for the client
         self.update_timers(client)
@@ -783,8 +784,7 @@ class Area:
             # Remove their owner status due to single_cm pref. remove_owner will unlock the area if they were the last CM.
             if client in self._owners:
                 self.remove_owner(client)
-                client.send_ooc(
-                    "You can only be a CM of a single area in this hub.")
+                client.send_ooc("You can only be a CM of a single area in this hub.")
         # Trigger this routine only if a non-privileged client left the area, and there are no GMs in this hub.
         if self.locking_allowed and len(self.real_cms()) <= 0 and len(self.area_manager.real_owners()) <= 0:
             # Since anyone can lock/unlock, unlock if we were the last client in this area and it was locked.
@@ -810,7 +810,7 @@ class Area:
         else:
             self.broadcast_player_list_to_target(client)
 
-        #Battle system
+        # Battle system
         if client in client.area.fighters:
             if client.area.battle_started:
                 client.battle.current_client = None
@@ -893,8 +893,7 @@ class Area:
         try:
             del self.links[str(target)]
         except KeyError:
-            raise AreaError(
-                f"Link {target} does not exist in Area {self.name}!")
+            raise AreaError(f"Link {target} does not exist in Area {self.name}!")
 
     def is_char_available(self, char_id):
         """
@@ -909,9 +908,7 @@ class Area:
 
     def get_rand_avail_char_id(self):
         """Get a random available character ID."""
-        avail_set = set(range(len(self.area_manager.char_list))) - {
-            x.char_id for x in self.clients
-        }
+        avail_set = set(range(len(self.area_manager.char_list))) - {x.char_id for x in self.clients}
         if len(avail_set) == 0:
             raise AreaError("No available characters.")
         return random.choice(tuple(avail_set))
@@ -931,11 +928,7 @@ class Area:
         for c in self.owners:
             if c in self.clients:
                 continue
-            if (
-                c.remote_listen == 3
-                or (cmd == "CT" and c.remote_listen == 2)
-                or (cmd == "MS" and c.remote_listen == 1)
-            ):
+            if c.remote_listen == 3 or (cmd == "CT" and c.remote_listen == 2) or (cmd == "MS" and c.remote_listen == 1):
                 c.send_command(cmd, *args)
 
     def send_owner_ic(self, bg, cmd, *args):
@@ -957,7 +950,7 @@ class Area:
         for c in self.clients:
             c.send_timer_set_time(timer_id, new_time, start)
 
-    def broadcast_ooc(self, msg, exclude_list = []):
+    def broadcast_ooc(self, msg, exclude_list=[]):
         """
         Broadcast an OOC message to all clients in the area.
         :param msg: message
@@ -966,9 +959,7 @@ class Area:
             if c in exclude_list:
                 continue
             c.send_command("CT", self.server.config["hostname"], msg, "1")
-        self.send_owner_command(
-            "CT", f"[{self.id}]" + self.server.config["hostname"], msg, "1"
-        )
+        self.send_owner_command("CT", f"[{self.id}]" + self.server.config["hostname"], msg, "1")
         # Discord Bridgebot
         if (
             "bridgebot" in self.server.config
@@ -978,9 +969,7 @@ class Area:
             and self.id == self.server.bridgebot.area_id
         ):
             if "ooc_system" in self.server.config["bridgebot"] and self.server.config["bridgebot"]["ooc_system"]:
-                self.server.bridgebot.queue_message(
-                    self.server.config["hostname"], msg
-                )
+                self.server.bridgebot.queue_message(self.server.config["hostname"], msg)
 
     def broadcast_action(self, client, msg):
         """
@@ -1001,51 +990,50 @@ class Area:
                 continue
             if not c.ooc_actions:
                 continue
-            if (
-                c.remote_listen == 3
-                or c.remote_listen == 2
-            ):
+            if c.remote_listen == 3 or c.remote_listen == 2:
                 c.send_command(cmd, f"[{self.id}]" + self.server.config["hostname"], msg, "1")
 
-    def send_ic(self,
-                client=None,
-                msg_type="1",
-                pre=0,
-                folder="",
-                anim="",
-                msg="",
-                pos="",
-                sfx="",
-                emote_mod=0,
-                cid=-1,
-                sfx_delay=0,
-                button=0,
-                evidence=[0],
-                flip=0,
-                ding=0,
-                color=0,
-                showname="",
-                charid_pair=-1,
-                other_folder="",
-                other_emote="",
-                offset_pair=0,
-                other_offset=0,
-                other_flip=0,
-                nonint_pre=0,
-                sfx_looping="0",
-                screenshake=0,
-                frames_shake="",
-                frames_realization="",
-                frames_sfx="",
-                additive=0,
-                effect="", 
-                targets=None,
-                third_charid=-1,
-                third_folder="",
-                third_emote=0,
-                third_offset="",
-                third_flip=0,
-                video=""):
+    def send_ic(
+        self,
+        client=None,
+        msg_type="1",
+        pre=0,
+        folder="",
+        anim="",
+        msg="",
+        pos="",
+        sfx="",
+        emote_mod=0,
+        cid=-1,
+        sfx_delay=0,
+        button=0,
+        evidence=[0],
+        flip=0,
+        ding=0,
+        color=0,
+        showname="",
+        charid_pair=-1,
+        other_folder="",
+        other_emote="",
+        offset_pair=0,
+        other_offset=0,
+        other_flip=0,
+        nonint_pre=0,
+        sfx_looping="0",
+        screenshake=0,
+        frames_shake="",
+        frames_realization="",
+        frames_sfx="",
+        additive=0,
+        effect="",
+        targets=None,
+        third_charid=-1,
+        third_folder="",
+        third_emote=0,
+        third_offset="",
+        third_flip=0,
+        video="",
+    ):
         """
         Send an IC message from a client to all applicable clients in the area.
         :param client: speaker
@@ -1061,22 +1049,17 @@ class Area:
                 lst = list(self.testimony[idx])
                 lst[4] = "}}}" + msg[2:]
                 self.testimony[idx] = tuple(lst)
-                self.broadcast_ooc(
-                    f"{client.showname} has amended Statement {idx+1}.")
+                self.broadcast_ooc(f"{client.showname} has amended Statement {idx+1}.")
                 if not self.recording:
                     self.testimony_send(idx)
             except IndexError:
-                client.send_ooc(
-                    f"Something went wrong, couldn't amend Statement {idx+1}!"
-                )
+                client.send_ooc(f"Something went wrong, couldn't amend Statement {idx+1}!")
             return
 
-        adding = msg.strip(
-        ) != "" and self.recording and client is not None
+        adding = msg.strip() != "" and self.recording and client is not None
         if client and msg.startswith("++") and len(self.testimony) > 0:
             if len(self.testimony) >= 30:
-                client.send_ooc(
-                    "Maximum testimony statement amount reached! (30)")
+                client.send_ooc("Maximum testimony statement amount reached! (30)")
                 return
             adding = True
         elif client:
@@ -1087,7 +1070,7 @@ class Area:
                 target = ""
                 # message contains an "at" sign aka we're referring to someone specific
                 if "@" in lwr:
-                    target = lwr[lwr.find("@") + 1:]
+                    target = lwr[lwr.find("@") + 1 :]
                 try:
                     opponent = None
                     target = target.lower()
@@ -1118,8 +1101,7 @@ class Area:
                         commands.ooc_cmd_concede(client, "")
                     # Shouter provided target but no opponent was found
                     elif target != "" or self.minigame in ["Cross Swords", "Scrum Debate"]:
-                        raise AreaError(
-                            "Interjection minigame - target not found!")
+                        raise AreaError("Interjection minigame - target not found!")
 
                     # Minigame didn't swap as a result of this shout, don't display the shout
                     if self.minigame != "" and self.minigame == old_minigame:
@@ -1176,23 +1158,17 @@ class Area:
                     client.area.last_ic_message is not None
                     and client.area.last_ic_message[8] == client.char_id
                     and client.area.last_ic_message[16] != -1
-                    and int(client.area.last_ic_message[16].split("^")[0])
-                    in opposing_team
+                    and int(client.area.last_ic_message[16].split("^")[0]) in opposing_team
                 ):
                     # Set the pair to the person who it was last msg
-                    charid_pair = int(
-                        client.area.last_ic_message[16].split("^")[0]
-                    )
+                    charid_pair = int(client.area.last_ic_message[16].split("^")[0])
                 # The person we were trying to find is no longer on the opposing team
                 else:
                     # Search through the opposing team's characters
                     for other_cid in opposing_team:
                         charid_pair = other_cid
                         # If last message's charid matches a member of this team, prioritize theirs
-                        if (
-                            client.area.last_ic_message is not None
-                            and other_cid == client.area.last_ic_message[8]
-                        ):
+                        if client.area.last_ic_message is not None and other_cid == client.area.last_ic_message[8]:
                             break
                 # If our pair opponent is found
                 if charid_pair != -1:
@@ -1223,8 +1199,7 @@ class Area:
                 or pos != self.last_ic_message[8]
                 or self.last_ic_message[4].strip() != ""
             ):
-                database.log_area("chat.ic", client,
-                                  client.area, message=msg)
+                database.log_area("chat.ic", client, client.area, message=msg)
 
         if targets is None:
             targets = self.clients
@@ -1237,12 +1212,7 @@ class Area:
                 continue
             # pos doesn't match listen_pos, we're not listening so make this an OOC message instead
             if c.area == self and c.listen_pos is not None:
-                if (
-                    type(c.listen_pos) is list
-                    and not (pos in c.listen_pos)
-                    or c.listen_pos == "self"
-                    and pos != c.pos
-                ):
+                if type(c.listen_pos) is list and not (pos in c.listen_pos) or c.listen_pos == "self" and pos != c.pos:
                     name = ""
                     if cid != -1:
                         name = self.area_manager.char_list[cid]
@@ -1251,8 +1221,7 @@ class Area:
                     # Send the mesage as OOC.
                     # Woulda been nice if there was a packet to send messages to IC log
                     # without displaying it in the viewport.
-                    c.send_command(
-                        "CT", f"[pos '{pos}'] {name}", msg)
+                    c.send_command("CT", f"[pos '{pos}'] {name}", msg)
                     continue
 
             # Before we send the message, if our remote_listen is different...
@@ -1262,51 +1231,52 @@ class Area:
             msg_to_send = msg
             if c.area != self:
                 msg_to_send = "}}}[" + str(self.id) + "] {{{" + msg
-            c.send_command("MS", msg_type,
-                           pre,
-                           folder,
-                           # if we're in first person mode, treat our msgs as narration
-                           "" if c == client and client.firstperson else anim,
-                           msg_to_send,
-                           pos,
-                           sfx,
-                           emote_mod,
-                           cid,
-                           sfx_delay,
-                           button,
-                           evidence,
-                           flip,
-                           ding,
-                           color,
-                           showname,
-                           charid_pair,
-                           other_folder,
-                           other_emote,
-                           offset_pair,
-                           other_offset,
-                           other_flip,
-                           nonint_pre,
-                           sfx_looping,
-                           screenshake,
-                           frames_shake,
-                           frames_realization,
-                           frames_sfx,
-                           additive,
-                           effect,
-                           third_charid,
-                           third_folder,
-                           third_emote,
-                           third_offset,
-                           third_flip,
-                           video)
+            c.send_command(
+                "MS",
+                msg_type,
+                pre,
+                folder,
+                # if we're in first person mode, treat our msgs as narration
+                "" if c == client and client.firstperson else anim,
+                msg_to_send,
+                pos,
+                sfx,
+                emote_mod,
+                cid,
+                sfx_delay,
+                button,
+                evidence,
+                flip,
+                ding,
+                color,
+                showname,
+                charid_pair,
+                other_folder,
+                other_emote,
+                offset_pair,
+                other_offset,
+                other_flip,
+                nonint_pre,
+                sfx_looping,
+                screenshake,
+                frames_shake,
+                frames_realization,
+                frames_sfx,
+                additive,
+                effect,
+                third_charid,
+                third_folder,
+                third_emote,
+                third_offset,
+                third_flip,
+                video,
+            )
         if self.recording:
             # See if the testimony is supposed to end here.
             scrunched = "".join(e for e in msg if e.isalnum())
             if len(scrunched) > 0 and scrunched.lower() == "end":
                 self.recording = False
-                self.broadcast_ooc(
-                    f"[{client.id}] {client.showname} has ended the testimony."
-                )
+                self.broadcast_ooc(f"[{client.id}] {client.showname} has ended the testimony.")
                 self.send_command("RT", "testimony1", 1)
                 return
         if anim == "" or pos == "":
@@ -1348,35 +1318,34 @@ class Area:
             frames_sfx,  # 27
             additive,  # 28
             effect,  # 29
-            third_charid, # 30
-            third_folder, # 31
-            third_emote, # 32
-            third_offset, # 33
-            third_flip, # 34
-            video, #35
+            third_charid,  # 30
+            third_folder,  # 31
+            third_emote,  # 32
+            third_offset,  # 33
+            third_flip,  # 34
+            video,  # 35
         )
         self.last_ic_message = args
 
-        if "doorman_webhook" in self.server.config and \
-            self.server.config["doorman_webhook"]["enabled"] and \
-            self.area_manager.id == int(self.server.config["doorman_webhook"]["hub_id"]) and \
-            self.id == int(self.server.config["doorman_webhook"]["area_id"]):
-            
+        if (
+            "doorman_webhook" in self.server.config
+            and self.server.config["doorman_webhook"]["enabled"]
+            and self.area_manager.id == int(self.server.config["doorman_webhook"]["hub_id"])
+            and self.id == int(self.server.config["doorman_webhook"]["area_id"])
+        ):
+
             living_clients = len(self.clients)
             afkers = len(self.afkers)
             doorman_needed = living_clients <= 1 or afkers >= living_clients - 1
             if doorman_needed and self.can_call_doorman() and client != None and client.area != None:
                 description = f"[{client.id}] {client.name} ({client.showname}) in hub [{client.area.area_manager.id}] {client.area.area_manager.name} [{client.area.id}] {client.area.name}"
                 description += f"\n{msg}"
-                asyncio.get_running_loop().call_soon(
-                    self.server.webhooks.doormancall, description
-                )
+                asyncio.get_running_loop().call_soon(self.server.webhooks.doormancall, description)
                 self.set_doorman_call_delay()
 
         if adding:
             if len(self.testimony) >= 30:
-                client.send_ooc(
-                    "Maximum testimony statement amount reached! (30)")
+                client.send_ooc("Maximum testimony statement amount reached! (30)")
                 return
             if msg.startswith("++"):
                 msg = msg[2:]
@@ -1424,12 +1393,12 @@ class Area:
                 frames_sfx,  # 27
                 additive,  # 28
                 effect,  # 29
-                third_charid, # 30
-                third_folder, # 31
-                third_emote, # 32
-                third_offset, # 33
-                third_flip, # 34
-                video, # 35
+                third_charid,  # 30
+                third_folder,  # 31
+                third_emote,  # 32
+                third_offset,  # 33
+                third_flip,  # 34
+                video,  # 35
             )
             if idx == -1:
                 # Add one statement at the very end.
@@ -1447,8 +1416,7 @@ class Area:
         """Begin the doorman cooldown."""
         try:
             self.doorman_call_time = round(
-                time.time() * 1000.0
-                + int(self.server.config["doorman_webhook"]["delay"]) * 1000.0
+                time.time() * 1000.0 + int(self.server.config["doorman_webhook"]["delay"]) * 1000.0
             )
         except:
             self.doorman_call_time = round(time.time() * 1000 + 60000)
@@ -1504,11 +1472,8 @@ class Area:
 
     def broadcast_player_list_to_target(self, target):
         return_data = {}
-        return_data['packet'] = 'player_list'
-        special_allowed = (
-            target.is_mod
-            or target in self.owners
-        )
+        return_data["packet"] = "player_list"
+        special_allowed = target.is_mod or target in self.owners
         player_data_to_send = list()
         player_stuff = list()
         if (self.can_getarea and not self.dark) or special_allowed:
@@ -1526,15 +1491,14 @@ class Area:
                 chara_client_info["id"] = str(c.id)
                 chara_client_info["afk"] = str(c in self.afkers)
 
-                #Append the Showname
+                # Append the Showname
                 # 1.5
                 player_stuff.append(str(c.showname))
                 chara_client_info["showname"] = str(c.showname)
 
                 # 1.5.1
-                
 
-                #Append the Character Name
+                # Append the Character Name
                 # 1.5
                 # if(c.icon_visible):
                 char_folder = "Spectator"
@@ -1546,7 +1510,7 @@ class Area:
                 #     player_stuff.append("")
                 #     chara_client_info["character"] = "NO_CHARA"
 
-                if(target.is_mod):
+                if target.is_mod:
                     # chara_client_info["HDID"] = str(c.hdid)
                     chara_client_info["IPID"] = str(c.ipid)
 
@@ -1554,16 +1518,16 @@ class Area:
                 #     chara_client_info["url"] = c.files[1]
 
                 # if(c.char_outfit):
-                #     chara_client_info["outfit"] = c.char_outfit 
+                #     chara_client_info["outfit"] = c.char_outfit
 
-                if(c.desc):
+                if c.desc:
                     chara_client_info["status"] = c.desc
                 player_data_to_send.append(chara_client_info)
-        return_data['data'] = player_data_to_send
-        
+        return_data["data"] = player_data_to_send
+
         json_data = json.dumps(return_data)
-        target.send_command('JSN', json_data)
-        target.send_command('LP', player_stuff)
+        target.send_command("JSN", json_data)
+        target.send_command("LP", player_stuff)
 
     def parse_msg_delay(self, msg):
         """Just returns the delay value between messages.
@@ -1585,7 +1549,7 @@ class Area:
             client.iniswap = char
         else:
             client.iniswap = ""
-        
+
         if self.iniswap_allowed:
             return False
         # Our client is narrating or blankposting via slash command
@@ -1648,19 +1612,13 @@ class Area:
             return
         if length == 0:
             self.remove_jukebox_vote(client, False)
-            if len(self.jukebox_votes) <= 1 or (
-                not self.music_looper or self.music_looper.cancelled()
-            ):
+            if len(self.jukebox_votes) <= 1 or (not self.music_looper or self.music_looper.cancelled()):
                 self.start_jukebox()
         else:
             self.remove_jukebox_vote(client, True)
-            self.jukebox_votes.append(
-                self.JukeboxVote(client, music_name, length, showname)
-            )
+            self.jukebox_votes.append(self.JukeboxVote(client, music_name, length, showname))
             client.send_ooc("Your song was added to the jukebox.")
-            if len(self.jukebox_votes) == 1 or (
-                not self.music_looper or self.music_looper.cancelled()
-            ):
+            if len(self.jukebox_votes) == 1 or (not self.music_looper or self.music_looper.cancelled()):
                 self.start_jukebox()
 
     def remove_jukebox_vote(self, client, silent):
@@ -1687,21 +1645,14 @@ class Area:
             song_list = self.server.music_list
 
             # Hub music list
-            if (
-                self.area_manager.music_ref != ""
-                and len(self.area_manager.music_list) > 0
-            ):
+            if self.area_manager.music_ref != "" and len(self.area_manager.music_list) > 0:
                 if self.area_manager.replace_music:
                     song_list = self.area_manager.music_list
                 else:
                     song_list = song_list + self.area_manager.music_list
 
             # Area music list
-            if (
-                self.music_ref != ""
-                and self.music_ref != self.area_manager.music_ref
-                and len(self.music_list) > 0
-            ):
+            if self.music_ref != "" and self.music_ref != self.area_manager.music_ref and len(self.music_list) > 0:
                 if self.replace_music:
                     song_list = self.music_list
                 else:
@@ -1712,11 +1663,9 @@ class Area:
                 if "category" in c:
                     # Either play a completely random category, or play a category the last song was in
                     if "songs" in c:
-                        if self.music == "" or self.music in [
-                            b["name"] for b in c["songs"]
-                        ]:
+                        if self.music == "" or self.music in [b["name"] for b in c["songs"]]:
                             for s in c["songs"]:
-                                looping = ("length" not in s or s["length"] == -1)
+                                looping = "length" not in s or s["length"] == -1
                                 if not looping or s["name"] == self.music:
                                     continue
                                 songs = songs + [s]
@@ -1746,10 +1695,7 @@ class Area:
         # we should check that.
         # We also do a check if we were the last to play a song, just in case.
         if not self.jukebox:
-            if (
-                self.music_player == "The Jukebox"
-                and self.music_player_ipid == "has no IPID"
-            ):
+            if self.music_player == "The Jukebox" and self.music_player_ipid == "has no IPID":
                 self.music = ""
             return
 
@@ -1757,8 +1703,7 @@ class Area:
 
         if vote_picked is None:
             self.music = ""
-            self.send_command("MC", self.music, -1, "", 1,
-                              0, int(MusicEffect.FADE_OUT))
+            self.send_command("MC", self.music, -1, "", 1, 0, int(MusicEffect.FADE_OUT))
             return
 
         if vote_picked.name == self.music:
@@ -1810,15 +1755,11 @@ class Area:
             else:
                 current_vote.chance += 1
 
-        length = (
-            vote_picked.length - 3
-        )  # Remove a few seconds to have a smooth fade out
+        length = vote_picked.length - 3  # Remove a few seconds to have a smooth fade out
         if length <= 0:  # Length not defined
             length = 120.0  # Play each song for at least 2 minutes
 
-        self.music_looper = asyncio.get_running_loop().call_later(
-            max(5, length), lambda: self.start_jukebox()
-        )
+        self.music_looper = asyncio.get_running_loop().call_later(max(5, length), lambda: self.start_jukebox())
 
     def set_ambience(self, name):
         self.ambience = name
@@ -1883,29 +1824,28 @@ class Area:
         for client in self.clients:
             client.send_command("BN", self.background, client.pos, self.overlay, mode)
 
-
     def change_background(self, bg, overlay="", mode=1):
         """
         Set the background and/or overlay.
-        
+
         parameters:
         bg:      background name
         silent:  should send the pre 2.8 packet or the new one?
         overlay: overlay name (optional)
-        
+
         :raises: AreaError if `bg` is not in background list
-        
+
         BN packet implementation:
-        
+
         Before 2.8 (Changes after sending a IC message):
         BN # <background name>
-        
+
         AO 2.8 (Clear viewport and update/change background position):
         BN # <background name> # <pos>
-        
+
         AOG 1.0 (Put a additional image on top of the character):
         BN # <background name> # <pos> # <overlay:str> # <mode:int>
-        
+
         mode: 0 = pre 2.8 version (change background after IC message)
               1 = 2.8 version (Change background immediately, clearing the viewport)
               2 = Change background without clearing the viewport
@@ -1913,7 +1853,7 @@ class Area:
 
         The client should be expected to implement at least the first two.
 
-        
+
         """
         if self.use_backgrounds_yaml:
             if len(self.server.backgrounds) <= 0:
@@ -1960,9 +1900,7 @@ class Area:
             False,
         )
         if value.lower() == "hub":
-            raise AreaError(
-                'Hub Status is a restricted value.'
-            )
+            raise AreaError("Hub Status is a restricted value.")
         if value.lower() == "lfp":
             value = "looking-for-players"
         self.status = value.upper()
@@ -2056,8 +1994,7 @@ class Area:
         # Update their judge buttons
         self.update_judge_buttons(client)
 
-        self.broadcast_ooc(
-            f"{client.showname} [{client.id}] is CM in this area now.")
+        self.broadcast_ooc(f"{client.showname} [{client.id}] is CM in this area now.")
 
     def remove_owner(self, client, dc=False):
         """
@@ -2092,9 +2029,7 @@ class Area:
             # Update their judge buttons
             self.update_judge_buttons(client)
 
-        self.broadcast_ooc(
-            f"{client.showname} [{client.id}] is no longer CM in this area."
-        )
+        self.broadcast_ooc(f"{client.showname} [{client.id}] is no longer CM in this area.")
 
     def broadcast_area_list(self, client=None, refresh=False):
         """
@@ -2129,8 +2064,7 @@ class Area:
         :return: time left until you can move again or 0.
         """
         secs = round(time.time() * 1000.0 - client.last_move_time)
-        total = sum([client.move_delay, self.move_delay,
-                    self.area_manager.move_delay])
+        total = sum([client.move_delay, self.move_delay, self.area_manager.move_delay])
         test = total * 1000.0 - secs
         if test > 0:
             return test
@@ -2194,28 +2128,31 @@ class Area:
             return
 
         valid_voters = [
-            c for c in self.clients if
-                not c.hidden and
-                not c in self.afkers and
-                not c in self.owners and
-                c.char_id not in client.area.blue_team and
-                c.char_id not in client.area.red_team
+            c
+            for c in self.clients
+            if not c.hidden
+            and not c in self.afkers
+            and not c in self.owners
+            and c.char_id not in client.area.blue_team
+            and c.char_id not in client.area.red_team
         ]
         if client not in valid_voters:
-            client.send_ooc("You're not qualified to vote-end this minigame! (You're a Spectator, Hidden or the area owner)")
+            client.send_ooc(
+                "You're not qualified to vote-end this minigame! (You're a Spectator, Hidden or the area owner)"
+            )
             return
         self.votes_cast.add(client)
         votes_casted = len(self.votes_cast)
         votes_needed = round(len(valid_voters) * self.votes_percentage)
 
-        info = f'[{client.id}] {client.showname} is voting to end the minigame!'
+        info = f"[{client.id}] {client.showname} is voting to end the minigame!"
 
         if votes_casted >= votes_needed:
             client.area.end_minigame("Voted to end.")
-            info += f'\nSuccessfully voted to end with ({votes_casted}/{votes_needed}) votes.'
+            info += f"\nSuccessfully voted to end with ({votes_casted}/{votes_needed}) votes."
         else:
-            info += f'({votes_casted}/{votes_needed}) votes left.'
-        
+            info += f"({votes_casted}/{votes_needed}) votes left."
+
         self.broadcast_ooc(info)
 
     def start_debate(self, client, target, pta=False):
@@ -2249,9 +2186,7 @@ class Area:
                 self.broadcast_ooc("🔴Red team conceded!")
                 self.end_minigame("~Red~ team conceded!")
                 return
-            self.broadcast_ooc(
-                f"[{client.id}] {client.showname} is now part of the {team} team!"
-            )
+            self.broadcast_ooc(f"[{client.id}] {client.showname} is now part of the {team} team!")
             database.log_area(
                 "minigame.sd",
                 client,
@@ -2262,8 +2197,7 @@ class Area:
             return
         elif self.minigame == "Cross Swords":
             if target == client:
-                self.broadcast_ooc(
-                    f"[{client.id}] {client.showname} conceded!")
+                self.broadcast_ooc(f"[{client.id}] {client.showname} conceded!")
                 self.end_minigame(f"[{client.id}] {client.showname} conceded!")
                 return
             if not self.can_scrum_debate:
@@ -2284,9 +2218,7 @@ class Area:
             self.minigame_schedule.cancel()
             self.minigame = "Scrum Debate"
             timer = timeleft + self.scrum_debate_added_time
-            self.broadcast_ooc(
-                f"[{client.id}] {client.showname} is now part of the {team} team!"
-            )
+            self.broadcast_ooc(f"[{client.id}] {client.showname} is now part of the {team} team!")
             database.log_area(
                 "minigame.sd",
                 client,
@@ -2301,8 +2233,7 @@ class Area:
             if pta and not self.can_panic_talk_action:
                 raise AreaError("You may not PTA in this area!")
             if client == target:
-                raise AreaError(
-                    "You cannot initiate a minigame against yourself!")
+                raise AreaError("You cannot initiate a minigame against yourself!")
             self.old_invite_list = self.invite_list
             self.old_muted = self.muted
 
@@ -2315,7 +2246,7 @@ class Area:
             self.blue_team.clear()
             self.red_team.add(client.char_id)
             self.blue_team.add(target.char_id)
-            
+
             self.votes_cast.clear()
             if pta:
                 self.minigame = "Panic Talk Action"
@@ -2341,12 +2272,10 @@ class Area:
                 song = self.cross_swords_song_start
         else:
             if target == client:
-                self.broadcast_ooc(
-                    f"[{client.id}] {client.showname} conceded!")
+                self.broadcast_ooc(f"[{client.id}] {client.showname} conceded!")
                 self.end_minigame(f"[{client.id}] {client.showname} conceded!")
                 return
-            raise AreaError(
-                f"{self.minigame} is happening! You cannot interrupt it.")
+            raise AreaError(f"{self.minigame} is happening! You cannot interrupt it.")
 
         timer = max(5, int(timer))
         # Timer ID 2 is used, start it

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -388,7 +388,14 @@ class AreaManager:
                 raise AreaError("May not remove last existing area!")
         clients = area.clients.copy()
         for client in clients:
-            client.set_area(target_area)
+            if getattr(client, "is_automation", False):
+                # The automation executor lives and dies with its home area.
+                area.area_manager.owners.discard(client)
+                area._owners.discard(client)
+                client.leave_area()
+                client.clear()
+            else:
+                client.set_area(target_area)
 
         # Update area links
         for ar in self.areas:
@@ -657,7 +664,7 @@ class AreaManager:
         for client in clients:
             for area in client.local_area_list:
                 cm = ""
-                if len(area.owners) > 0:
+                if area.get_owners():
                     cm = area.get_owners()
                 cms_list.append(cm)
             self.server.send_arup(client, cms_list)

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -1,12 +1,12 @@
-from server import commands
 from server.exceptions import ClientError, AreaError, ArgumentError, ServerError
 from server.area import Area
+from server.timer import Timer
+from server.remote_client import RemoteClient
 from collections import OrderedDict
 from server.constants import derelative
 
 import oyaml as yaml  # ordered yaml
 import os
-import datetime
 import logging
 
 logger = logging.getLogger("areamanager")
@@ -14,76 +14,6 @@ logger = logging.getLogger("areamanager")
 
 class AreaManager:
     """Holds the list of all areas."""
-
-    class Timer:
-        """Represents a single instance of a timer in the area."""
-
-        def __init__(
-            self,
-            Set=False,
-            started=False,
-            static=None,
-            target=None,
-            hub=None,
-            caller=None,
-        ):
-            self.set = Set
-            self.started = started
-            self.static = static
-            self.target = target
-            self.hub = hub
-            self.caller = caller
-            self.schedule = None
-            self.commands = []
-            self.format = "hh:mm:ss.zzz"
-            self.interval = 16
-
-        def timer_expired(self):
-            if self.schedule:
-                self.schedule.cancel()
-            # the hub was destroyed at some point
-            if self.hub is None or self is None:
-                return
-
-            self.static = datetime.timedelta(0)
-            self.started = False
-
-            self.hub.broadcast_ooc("Timer 0 has expired.")
-            self.call_commands()
-
-        def call_commands(self):
-            if self.caller is None:
-                return
-            if self.hub is None or self is None:
-                return
-            if self.caller not in self.hub.owners:
-                return
-            # We clear out the commands as we call them in order one by one
-            while len(self.commands) > 0:
-                # Take the first command in the list and run it
-                cmd = self.commands.pop(0)
-                args = cmd.split(" ")
-                cmd = args.pop(0).lower()
-                arg = ""
-                if len(args) > 0:
-                    arg = " ".join(args)[:1024]
-                try:
-                    commands.call(self.caller, cmd, arg)
-                except (ClientError, AreaError, ArgumentError, ServerError) as ex:
-                    self.caller.send_ooc(f"[Timer 0] {ex}")
-                    # Command execution critically failed somewhere. Clear out all commands so the timer doesn't screw with us.
-                    self.commands.clear()
-                    # Even tho self.commands.clear() is going to break us out of the while loop, manually return anyway just to be safe.
-                    return
-                except Exception as ex:
-                    self.caller.send_ooc(
-                        f"[Timer 0] An internal error occurred: {ex}. Please inform the staff of the server about the issue."
-                    )
-                    logger.error("Exception while running a command")
-                    # Command execution critically failed somewhere. Clear out all commands so the timer doesn't screw with us.
-                    self.commands.clear()
-                    # Even tho self.commands.clear() is going to break us out of the while loop, manually return anyway just to be safe.
-                    return
 
     def __init__(self, hub_manager, name):
         self.hub_manager = hub_manager
@@ -130,7 +60,7 @@ class AreaManager:
         # Time of day for this hub
         self.time_of_day = ""
 
-        self.timer = self.Timer()
+        self.timer = Timer(0, hub=self)
         
         # RPS-5 rules as default
         self.rps_rules = [
@@ -525,6 +455,14 @@ class AreaManager:
         )
         client.hide(True)
 
+    def real_owners(self):
+        """
+        GMs that are real players, excluding system executors (RemoteClient).
+        The script executor holds GM permission for command checks but must
+        not drive GM lifecycle events like hub-name resets.
+        """
+        return {o for o in self.owners if not isinstance(o, RemoteClient)}
+
     def remove_owner(self, client):
         """
         Remove a GM from the Hub.
@@ -534,7 +472,7 @@ class AreaManager:
             client.broadcast_list.clear()
             client.send_ooc("Your broadcast list has been cleared.")
 
-        if len(self.owners) == 0:
+        if len(self.real_owners()) == 0:
             # To prevent people egging on the hub list by making epic meme names and bailing
             self.name = self.o_name
             self.abbreviation = self.o_abbreviation
@@ -554,7 +492,7 @@ class AreaManager:
         :return: message
         """
         gms = set()
-        for gm in self.owners:
+        for gm in self.real_owners():
             gms.add(gm.name)
         return ", ".join(gms)
 
@@ -681,8 +619,9 @@ class AreaManager:
             for area in client.local_area_list:
                 playercount = -1
                 if not self.hide_clients and not area.hide_clients:
+                    from server.remote_client import _SYSTEM_IPID
                     playercount = len(
-                        [c for c in area.clients if not c.hidden])
+                        [c for c in area.clients if not c.hidden and c.ipid != _SYSTEM_IPID])
                     playerhubcount = playerhubcount + playercount
                 players_list.append(playercount)
             if multiple_hubs and len(client.local_area_list) > 0:

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -1020,6 +1020,11 @@ class ClientManager:
             :param target_pos: which position to target in the new area
             """
             old_area = self.area
+            if getattr(self, "is_automation", False):
+                if not self.is_gm:
+                    raise ClientError("The automation executor cannot leave its area.")
+                if old_area.area_manager != area.area_manager:
+                    raise ClientError("The automation executor cannot change hubs.")
             # If this person switched hubs
             if old_area.area_manager != area.area_manager:
                 # Make sure a single person can't hoard all the hubs
@@ -1587,7 +1592,7 @@ class ClientManager:
             if self.area.area_manager.arup_enabled:
                 status = f" [{area.status}]"
             owner = ""
-            if len(area._owners) > 0:
+            if area.get_owners():
                 owner = f"[CM(s): {area.get_owners()}]"
             hidden = "📦" if area.hidden else ""
             locked = "🔒" if area.locked else ""

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -10,6 +10,7 @@ from heapq import heappop, heappush
 from server import database
 from server.constants import TargetType, encode_ao_packet, contains_URL, derelative
 from server.exceptions import ClientError, AreaError, ServerError
+from server.constants import _SYSTEM_IPID
 
 import oyaml as yaml  # ordered yaml
 import json
@@ -1072,7 +1073,6 @@ class ClientManager:
                 count = 0
                 for c in hub.clients:
                     if not c.area.hide_clients and not c.hidden:
-                        from server.remote_client import _SYSTEM_IPID
                         if c.ipid != _SYSTEM_IPID:
                             count = count + 1
                 hub.count = count
@@ -1613,14 +1613,12 @@ class ClientManager:
                     users = ''
                 else:
                     # We exclude hidden players and system/mock clients here
-                    from server.remote_client import _SYSTEM_IPID
                     player_list = [c for c in area.clients if not c.hidden and c.ipid != _SYSTEM_IPID]
                     users = f' (users: {len(player_list)}) '
                 if area.hidden:
                     return ""
             else:
                 # Mods see everyone; GMs and CMs don't see system/mock clients
-                from server.remote_client import _SYSTEM_IPID
                 if self.is_mod:
                     users = f' (users: {len(area.clients)}) '
                 else:
@@ -1643,7 +1641,6 @@ class ClientManager:
 
             # Filter out system/mock clients for non-mods
             if not self.is_mod:
-                from server.remote_client import _SYSTEM_IPID
                 player_list = [c for c in player_list if c.ipid != _SYSTEM_IPID]
 
             if not self.is_mod and self not in area.owners:
@@ -1826,11 +1823,11 @@ class ClientManager:
                         hub_count = 0
                         for area in hub.areas:
                             if not area.hide_clients and not area.dark:
-                                player_list = [c for c in area.clients if not c.hidden]
+                                player_list = [c for c in area.clients if not c.hidden and c.ipid != _SYSTEM_IPID]
                                 hub_count += len(player_list)
                         info += f"\n⛩[{hub.id}]{hub.name} (users: {hub_count})⛩:\n{hub_info}\n"
                     else:
-                        info += f"\n⛩[{hub.id}]{hub.name} (users: {len(hub.clients)})⛩:\n{hub_info}\n"
+                        info += f"\n⛩[{hub.id}]{hub.name} (users: {len([c for c in hub.clients if c.ipid != _SYSTEM_IPID])})⛩:\n{hub_info}\n"
             if afk_check:
                 info += f"Current AFK-ers: {cnt}"
             else:
@@ -1860,14 +1857,14 @@ class ClientManager:
             msg = "🌐 Hubs 🌐"
             for hub in self.server.hub_manager.hubs:
                 owner = "FREE"
-                if len(hub.owners) > 0:
+                if len(hub.real_owners()) > 0:
                     owner = hub.get_gms()
                 msg += "\r\n"
                 if self.area.area_manager == hub:
                     msg += " ◽ "
                 else:
                     msg += " ◾ "
-                msg += f"[{hub.id}] {hub.name} (users: {len([c for c in hub.clients if not c.hidden])}) GM(s): {owner}"
+                msg += f"[{hub.id}] {hub.name} (users: {len([c for c in hub.clients if not c.hidden and c.ipid != _SYSTEM_IPID])}) GM(s): {owner}"
             self.send_ooc(msg)
 
         def send_done(self):
@@ -2421,7 +2418,7 @@ class ClientManager:
         for hub in self.server.hub_manager.hubs:
             count = 0
             for c in hub.clients:
-                if not c.area.hide_clients and not c.hidden:
+                if not c.area.hide_clients and not c.hidden and c.ipid != _SYSTEM_IPID:
                     count = count + 1
             hub.count = count
         for c in self.server.client_manager.clients:

--- a/server/commands/__init__.py
+++ b/server/commands/__init__.py
@@ -1,17 +1,28 @@
-def call(client, cmd, arg):
+def resolve_command(server, cmd):
+    """
+    Resolve a command name to its `ooc_cmd_<name>` function, following the
+    server's command aliases. Returns `None` if the command doesn't exist.
+    """
     import sys
 
     me = sys.modules[__name__]
     called_function = f"ooc_cmd_{cmd}"
-    if len(client.server.command_aliases) > 0 and not hasattr(me, called_function):
-        if cmd in client.server.command_aliases:
-            called_function = f"ooc_cmd_{client.server.command_aliases[cmd]}"
+    if len(server.command_aliases) > 0 and not hasattr(me, called_function):
+        if cmd in server.command_aliases:
+            called_function = f"ooc_cmd_{server.command_aliases[cmd]}"
     if not hasattr(me, called_function):
+        return None
+    return getattr(me, called_function)
+
+
+def call(client, cmd, arg):
+    func = resolve_command(client.server, cmd)
+    if func is None:
         client.send_ooc(
             f"Invalid command: {cmd}. Use /help to find up-to-date commands."
         )
         return
-    getattr(me, called_function)(client, arg)
+    func(client, arg)
 
 
 def submodules():
@@ -97,10 +108,13 @@ def mod_only(area_owners=False, hub_owners=False):
     def decorator(func):
         @functools.wraps(func)
         def wrapper_mod_only(client, arg, *args, **kwargs):
+            # System executors (e.g. RemoteClient with is_gm=True) act as a
+            # GM: they pass area-owner and hub-owner gates but never mod-only.
+            is_gm = getattr(client, "is_gm", False)
             if (
                 not client.is_mod
-                and (not area_owners or client not in client.area.owners)
-                and (not hub_owners or client not in client.area.area_manager.owners)
+                and (not area_owners or not (client in client.area.owners or is_gm))
+                and (not hub_owners or not (client in client.area.area_manager.owners or is_gm))
             ):
                 raise ClientError("You must be authorized to do that.")
             func(client, arg, *args, **kwargs)

--- a/server/commands/character.py
+++ b/server/commands/character.py
@@ -38,6 +38,8 @@ __all__ = [
     "ooc_cmd_unlisten_pos",
     "ooc_cmd_save_character_data",
     "ooc_cmd_load_character_data",
+    "ooc_cmd_get_char_data",
+    "ooc_cmd_set_char_data",
     "ooc_cmd_keys_set",
     "ooc_cmd_keys_add",
     "ooc_cmd_keys_remove",
@@ -898,6 +900,70 @@ def ooc_cmd_load_character_data(client, arg):
         client.send_ooc(f"Loading {arg} character data...")
     except AreaError:
         raise
+
+
+def _resolve_char_arg(hub, text):
+    """Resolve a character id or folder name to a character id."""
+    if text.isdigit():
+        char_id = int(text)
+        if not hub.is_valid_char_id(char_id):
+            raise ArgumentError(f"Unknown character id {char_id}.")
+        return char_id
+    try:
+        return hub.get_char_id_by_name(text)
+    except ServerError:
+        raise ArgumentError(f"Unknown character '{text}'.")
+
+
+@mod_only(hub_owners=True)
+def ooc_cmd_get_char_data(client, arg):
+    """
+    View the custom data saved for a character (or a single key of it).
+    Usage: /get_char_data <char id|folder> [key]
+    """
+    args = arg.split()
+    if len(args) < 1:
+        raise ArgumentError("Please provide a character id or folder name.")
+    hub = client.area.area_manager
+    folder = hub.char_list[_resolve_char_arg(hub, args[0])]
+    data = hub.character_data.get(folder, {})
+    if len(args) >= 2:
+        key = args[1]
+        if key not in data:
+            raise ArgumentError(f"Character '{folder}' has no data key '{key}'.")
+        client.send_ooc(f"{folder}.{key} = {data[key]}")
+        return
+    if not data:
+        client.send_ooc(f"Character '{folder}' has no saved data.")
+        return
+    for key, value in data.items():
+        client.send_ooc(f"{folder}.{key} = {value}")
+
+
+@mod_only(hub_owners=True)
+def ooc_cmd_set_char_data(client, arg):
+    """
+    Set (or clear) a custom data key for a character; omit the value to remove the key.
+    Usage: /set_char_data <char id|folder> <key> [value...]
+    """
+    parts = arg.split(None, 2)
+    if len(parts) < 2:
+        raise ArgumentError("Usage: /set_char_data <char id|folder> <key> [value...]")
+    hub = client.area.area_manager
+    folder = hub.char_list[_resolve_char_arg(hub, parts[0])]
+    key = parts[1]
+    data = hub.character_data.setdefault(folder, {})
+    if len(parts) < 3 or not parts[2].strip():
+        if key in data:
+            del data[key]
+            client.send_ooc(f"Removed '{folder}.{key}'.")
+        else:
+            client.send_ooc(f"Character '{folder}' has no data key '{key}'.")
+    else:
+        value = parts[2]
+        hub.set_character_data(folder, key, value)
+        client.send_ooc(f"Set '{folder}.{key}' = {value}.")
+    hub.save_character_data()
 
 
 def mod_keys(client, arg, mod=0):

--- a/server/commands/hubs.py
+++ b/server/commands/hubs.py
@@ -939,7 +939,7 @@ def ooc_cmd_gm(client, arg):
     """
     if not client.is_mod and not client.area.area_manager.can_gm:
         raise ClientError("You can't become a GM in this Hub!")
-    if len(client.area.area_manager.owners) == 0 or client.is_mod or client in client.area.area_manager.owners:
+    if len(client.area.area_manager.real_owners()) == 0 or client.is_mod or client in client.area.area_manager.owners:
         # Client is trying to make someone else a GM
         if arg != "":
             # GM all self clients

--- a/server/commands/roleplay.py
+++ b/server/commands/roleplay.py
@@ -910,7 +910,8 @@ def ooc_cmd_demo(client, arg):
         client.area.stop_demo()
         client.send_ooc("Stopping demo playback...")
         return
-    if (time.time() * 1000 - client.last_demo_call) < 1000:
+    rate_limit_ms = client.server.config.get("demo_rate_limit_ms", 1000)
+    if rate_limit_ms > 0 and (time.time() * 1000 - client.last_demo_call) < rate_limit_ms:
         client.send_ooc("Please wait a bit before calling /demo again!")
         return
     evidence = None

--- a/server/commands/roleplay.py
+++ b/server/commands/roleplay.py
@@ -10,6 +10,7 @@ from server import database
 from server.constants import TargetType
 from server.exceptions import ClientError, ServerError, ArgumentError
 from server.remote_client import RemoteClient
+from server.scripting import evaluate_expression, ScriptingError, DivisionByZeroError
 
 from . import mod_only
 
@@ -48,7 +49,6 @@ def rtd(arg):
     MODIFIER_LENGTH_MAX = 12  # Change to a higher at your own risk
     ACCEPTABLE_IN_MODIFIER = "1234567890+-*/().r"
     MAXDIVZERO_ATTEMPTS = 10
-    MAXACCEPTABLETERM = DICE_MAX * 10  # Change to a higher number at your own risk
 
     special_calculation = False
     args = arg.split(" ")
@@ -58,9 +58,7 @@ def rtd(arg):
         if arg_length == 2:
             dice_type, modifiers = args
             if len(modifiers) > MODIFIER_LENGTH_MAX:
-                raise ArgumentError(
-                    "The given modifier is too long to compute. Please try a shorter one"
-                )
+                raise ArgumentError("The given modifier is too long to compute. Please try a shorter one")
         elif arg_length == 1:
             dice_type, modifiers = arg, ""
         else:
@@ -77,31 +75,20 @@ def rtd(arg):
         try:
             num_dice, chosen_max = int(dice_type[0]), int(dice_type[1])
         except ValueError:
-            raise ArgumentError(
-                "Expected integer value for number of rolls and max value of dice"
-            )
+            raise ArgumentError("Expected integer value for number of rolls and max value of dice")
 
         if not 1 <= num_dice <= NUMDICE_MAX:
-            raise ArgumentError(
-                "Number of rolls must be between 1 and {}".format(NUMDICE_MAX)
-            )
+            raise ArgumentError("Number of rolls must be between 1 and {}".format(NUMDICE_MAX))
         if not 1 <= chosen_max <= DICE_MAX:
-            raise ArgumentError(
-                "Dice value must be between 1 and {}".format(DICE_MAX))
+            raise ArgumentError("Dice value must be between 1 and {}".format(DICE_MAX))
 
         for char in modifiers:
             if char not in ACCEPTABLE_IN_MODIFIER:
-                raise ArgumentError(
-                    "Expected numbers and standard mathematical operations in modifier"
-                )
+                raise ArgumentError("Expected numbers and standard mathematical operations in modifier")
             if char == "r":
                 special_calculation = True
-        if (
-            "**" in modifiers
-        ):  # Exponentiation manually disabled, it can be pretty dangerous
-            raise ArgumentError(
-                "Expected numbers and standard mathematical operations in modifier"
-            )
+        if "**" in modifiers:  # Exponentiation manually disabled, it can be pretty dangerous
+            raise ArgumentError("Expected numbers and standard mathematical operations in modifier")
     else:
         num_dice, chosen_max, modifiers = 1, 6, ""  # Default
 
@@ -123,41 +110,19 @@ def rtd(arg):
                 else:
                     aux_modifier = raw_roll + modifiers + "="
 
-                # Prevent any terms from reaching past MAXACCEPTABLETERM in order to prevent server lag due to potentially frivolous dice rolls
-                aux = aux_modifier[:-1]
-                for i in "+-*/()":
-                    aux = aux.replace(i, "!")
-                aux = aux.split("!")
-                for i in aux:
-                    try:
-                        if i != "" and round(float(i)) > MAXACCEPTABLETERM:
-                            raise ArgumentError(
-                                "Given mathematical formula takes numbers past the server's computation limit"
-                            )
-                    except ValueError:
-                        raise ArgumentError(
-                            "Given mathematical formula has a syntax error and cannot be computed"
-                        )
-
                 try:
                     mid_roll = round(
-                        eval(aux_modifier[:-1])
-                    )  # By this point it should be 'safe' to run eval
-                except SyntaxError:
-                    raise ArgumentError(
-                        "Given mathematical formula has a syntax error and cannot be computed"
-                    )
-                except TypeError:  # Deals with inputs like 3(r-1)
-                    raise ArgumentError(
-                        "Given mathematical formula has a syntax error and cannot be computed"
-                    )
-                except ZeroDivisionError:
+                        evaluate_expression(aux_modifier[:-1])
+                    )  # Shared, whitelisted evaluator from server/scripting
+                except DivisionByZeroError:
                     divzero_attempts += 1
                     if divzero_attempts == MAXDIVZERO_ATTEMPTS:
                         raise ArgumentError(
                             "Given mathematical formula produces divisions by zero too often and cannot be computed"
                         )
                     continue
+                except ScriptingError:
+                    raise ArgumentError("Given mathematical formula has a syntax error and cannot be computed")
             break
 
         final_roll = mid_roll  # min(chosen_max,max(1,mid_roll))
@@ -192,9 +157,7 @@ def ooc_cmd_roll(client, arg):
         f"[👉🎲] [{client.id}] {client.showname} rolled:\n {roll} out of {chosen_max}."
         + (f"\nThe total sum is {Sum}." if num_dice > 1 else "")
     )
-    database.log_area(
-        "roll", client, client.area, message=f"{roll} out of {chosen_max}"
-    )
+    database.log_area("roll", client, client.area, message=f"{roll} out of {chosen_max}")
 
 
 def ooc_cmd_rollp(client, arg):
@@ -208,20 +171,15 @@ def ooc_cmd_rollp(client, arg):
     roll, num_dice, chosen_max, _modifiers, Sum = rtd(arg)
 
     client.send_ooc(
-        f"[Hidden] You rolled {roll} out of {chosen_max}."
-        + (f"\nThe total sum is {Sum}." if num_dice > 1 else "")
+        f"[Hidden] You rolled {roll} out of {chosen_max}." + (f"\nThe total sum is {Sum}." if num_dice > 1 else "")
     )
     for c in client.area.owners:
-        c.send_ooc(
-            f"[{client.area.id}]{client.showname} secretly rolled {roll} out of {chosen_max}."
-        )
+        c.send_ooc(f"[{client.area.id}]{client.showname} secretly rolled {roll} out of {chosen_max}.")
     client.area.send_owner_command(
         f"[👉🎲] [{client.id}] {client.showname} secretly rolled:\n {roll} out of {chosen_max}."
         + (f"\nThe total sum is {Sum}." if num_dice > 1 else "")
     )
-    database.log_area(
-        "rollp", client, client.area, message=f"{roll} out of {chosen_max}"
-    )
+    database.log_area("rollp", client, client.area, message=f"{roll} out of {chosen_max}")
 
 
 def ooc_cmd_notecard(client, arg):
@@ -249,9 +207,7 @@ def ooc_cmd_notecard_clear(client, arg):
     Usage: /notecard_clear
     """
     client.area.cards.clear()
-    client.area.broadcast_ooc(
-        f"[{client.id}] {client.showname} has cleared all the note cards in this area."
-    )
+    client.area.broadcast_ooc(f"[{client.id}] {client.showname} has cleared all the note cards in this area.")
     database.log_area("notecard_clear", client, client.area)
 
 
@@ -269,14 +225,12 @@ def ooc_cmd_notecard_reveal(client, arg):
         card_showname = card_data[0]
         card_msg = card_data[1]
         card_owner_display = f"[DC] {card_showname}"
-        card_owner = client.server.client_manager.get_targets(
-            client, TargetType.CHAR_NAME, card_charname, False
-        )
+        card_owner = client.server.client_manager.get_targets(client, TargetType.CHAR_NAME, card_charname, False)
         if len(card_owner) > 0:
             card_owner = card_owner[0]
             card_owner_display = f"[{card_owner.id}] {card_owner.showname}"
         msg += f"\n{card_owner_display}: {card_msg}"
-    
+
     # Reveal the notecards in OOC!
     client.area.broadcast_ooc(msg)
 
@@ -285,9 +239,7 @@ def ooc_cmd_notecard_reveal(client, arg):
         client.send_ooc("Use /notecard_clear for clearing.")
     else:
         client.area.cards.clear()
-        client.area.broadcast_ooc(
-            f"Notecards have been cleared."
-        )
+        client.area.broadcast_ooc(f"Notecards have been cleared.")
 
     database.log_area("notecard_reveal", client, client.area)
 
@@ -300,26 +252,20 @@ def ooc_cmd_notecard_check(client, arg):
     """
     if len(client.area.cards) == 0:
         raise ClientError("There are no notecards to check in this area.")
-    client.area.broadcast_ooc(
-        f"[{client.id}] {client.showname} has checked the notecards in this area."
-    )
+    client.area.broadcast_ooc(f"[{client.id}] {client.showname} has checked the notecards in this area.")
     msg = "Notecards in this area:"
     for card_charname, card_data in client.area.cards.items():
         card_showname = card_data[0]
         card_msg = card_data[1]
         card_owner_display = f"[DC] {card_showname}"
-        card_owner = client.server.client_manager.get_targets(
-            client, TargetType.CHAR_NAME, card_charname, False
-        )
+        card_owner = client.server.client_manager.get_targets(client, TargetType.CHAR_NAME, card_charname, False)
         if len(card_owner) > 0:
             card_owner = card_owner[0]
             card_owner_display = f"[{card_owner.id}] {card_owner.showname}"
         msg += f"\n{card_owner_display}: {card_msg}"
 
     client.send_ooc(msg)
-    client.send_ooc(
-        "Use /notecard_clear for clearing, or /notecard_reveal to reveal the results publicly."
-    )
+    client.send_ooc("Use /notecard_clear for clearing, or /notecard_reveal to reveal the results publicly.")
     database.log_area("notecard_check", client, client.area)
 
 
@@ -332,12 +278,8 @@ def ooc_cmd_vote(client, arg):
     if len(args) == 0:
         raise ArgumentError("Please provide a client ID. Usage: /vote <id>.")
     if client.char_name in [y for x in client.area.votes.values() for y in x]:
-        raise ArgumentError(
-            "You already cast your vote! Wait on the CM to /vote_clear."
-        )
-    target = client.server.client_manager.get_targets(
-        client, TargetType.ID, int(args[0]), False
-    )[0]
+        raise ArgumentError("You already cast your vote! Wait on the CM to /vote_clear.")
+    target = client.server.client_manager.get_targets(client, TargetType.ID, int(args[0]), False)[0]
     client.area.votes.setdefault(target.char_name, []).append(client.char_name)
     client.area.broadcast_ooc(f"[{client.id}] {client.showname} cast a vote.")
     database.log_area("vote", client, client.area)
@@ -354,26 +296,20 @@ def ooc_cmd_vote_clear(client, arg):
         for value in client.area.votes.values():
             if arg in value:
                 value.remove(arg)
-                client.area.broadcast_ooc(
-                    f"[{client.id}] {client.showname} has cleared {arg}'s vote."
-                )
+                client.area.broadcast_ooc(f"[{client.id}] {client.showname} has cleared {arg}'s vote.")
                 return
         raise ClientError(
             f"No vote was cast by {arg}! (This is case-sensitive - are you sure you spelled the voter character folder right?)"
         )
     client.area.votes.clear()
-    client.area.broadcast_ooc(
-        f"[{client.id}] {client.showname} has cleared all the votes in this area."
-    )
+    client.area.broadcast_ooc(f"[{client.id}] {client.showname} has cleared all the votes in this area.")
     database.log_area("vote_clear", client, client.area)
 
 
 def get_vote_results(client, votes):
     def get_showname(target_name):
         """Helper function to convert a charname to showname format."""
-        owners = client.server.client_manager.get_targets(
-            client, TargetType.CHAR_NAME, target_name, False
-        )
+        owners = client.server.client_manager.get_targets(client, TargetType.CHAR_NAME, target_name, False)
         if owners:
             owner = owners[0]
             return f"[{owner.id}] {owner.showname}"
@@ -381,38 +317,36 @@ def get_vote_results(client, votes):
 
     # Sort votes by count (ascending)
     sorted_votes = sorted(votes.items(), key=lambda x: len(x[1]))
-    
+
     msg_lines = []
     max_votes = 0
-    
+
     for candidate, voters in sorted_votes:
         # Process voters
         voter_names = [get_showname(voter) for voter in voters]
         voters_str = ", ".join(voter_names)
-        
+
         # Process candidate
         candidate_name = get_showname(candidate)
-        
+
         # Build vote line
         vote_count = len(voters)
         plural = "s" if vote_count > 1 else ""
-        msg_lines.append(
-            f"🗳️{vote_count} vote{plural} for {candidate_name}\n   ◽ Voted by {voters_str}."
-        )
-        
+        msg_lines.append(f"🗳️{vote_count} vote{plural} for {candidate_name}\n   ◽ Voted by {voters_str}.")
+
         # Track max votes
         if vote_count > max_votes:
             max_votes = vote_count
-    
+
     # Find winners
     winners = [get_showname(k) for k, v in sorted_votes if len(v) == max_votes]
-    
+
     # Add winner/tie message
     if len(winners) > 1:
         msg_lines.append(f"{', '.join(winners)} have tied for most votes.")
     else:
         msg_lines.append(f"{winners[0]} has most votes.")
-    
+
     return "\n".join(msg_lines)
 
 
@@ -433,9 +367,7 @@ def ooc_cmd_vote_reveal(client, arg):
         client.send_ooc("Use /vote_clear for clearing.")
     else:
         client.area.votes.clear()
-        client.area.broadcast_ooc(
-            f"Votes have been cleared."
-        )
+        client.area.broadcast_ooc(f"Votes have been cleared.")
 
     database.log_area("vote_reveal", client, client.area)
 
@@ -448,15 +380,11 @@ def ooc_cmd_vote_check(client, arg):
     """
     if len(client.area.votes) == 0:
         raise ClientError("There are no votes to check in this area.")
-    client.area.broadcast_ooc(
-        f"[{client.id}] {client.showname} has checked the votes in this area."
-    )
+    client.area.broadcast_ooc(f"[{client.id}] {client.showname} has checked the votes in this area.")
     msg = "Votes in this area:\n"
     msg += get_vote_results(client, client.area.votes)
     client.send_ooc(msg)
-    client.send_ooc(
-        "Use /vote_clear for clearing, or /vote_reveal to reveal the results publicly."
-    )
+    client.send_ooc("Use /vote_clear for clearing, or /vote_reveal to reveal the results publicly.")
     database.log_area("vote_check", client, client.area)
 
 
@@ -478,9 +406,7 @@ def rolla_reload(area):
         with open("config/dice.yaml", "r", encoding="utf-8") as dice:
             area.ability_dice = yaml.safe_load(dice)
     except Exception:
-        raise ServerError(
-            "There was an error parsing the ability dice configuration. Check your syntax."
-        )
+        raise ServerError("There was an error parsing the ability dice configuration. Check your syntax.")
 
 
 def ooc_cmd_rolla_set(client, arg):
@@ -492,13 +418,9 @@ def ooc_cmd_rolla_set(client, arg):
         rolla_reload(client.area)
     available_sets = ", ".join(client.area.ability_dice.keys())
     if len(arg) == 0:
-        raise ArgumentError(
-            f"You must specify the ability set name.\nAvailable sets: {available_sets}"
-        )
+        raise ArgumentError(f"You must specify the ability set name.\nAvailable sets: {available_sets}")
     elif arg not in client.area.ability_dice:
-        raise ArgumentError(
-            f"Invalid ability set '{arg}'.\nAvailable sets: {available_sets}"
-        )
+        raise ArgumentError(f"Invalid ability set '{arg}'.\nAvailable sets: {available_sets}")
     client.ability_dice_set = arg
     client.send_ooc(f"Set ability set to {arg}.")
 
@@ -518,16 +440,11 @@ def ooc_cmd_rolla(client, arg):
     if not hasattr(client.area, "ability_dice"):
         rolla_reload(client.area)
     if not hasattr(client, "ability_dice_set"):
-        raise ClientError(
-            "You must set your ability set using /rolla_set <name>.")
+        raise ClientError("You must set your ability set using /rolla_set <name>.")
     ability_dice = client.area.ability_dice[client.ability_dice_set]
     roll, max_roll, ability = rolla(ability_dice)
-    client.area.broadcast_ooc(
-        f"[{client.id}] {client.showname} rolled a {roll} (out of {max_roll}): {ability}."
-    )
-    database.log_area(
-        "rolla", client, client.area, message=f"{roll} out of {max_roll}: {ability}"
-    )
+    client.area.broadcast_ooc(f"[{client.id}] {client.showname} rolled a {roll} (out of {max_roll}): {ability}.")
+    database.log_area("rolla", client, client.area, message=f"{roll} out of {max_roll}: {ability}")
 
 
 def ooc_cmd_coinflip(client, arg):
@@ -539,9 +456,7 @@ def ooc_cmd_coinflip(client, arg):
         raise ArgumentError("This command has no arguments.")
     coin = ["heads", "tails"]
     flip = random.choice(coin)
-    client.area.broadcast_ooc(
-        f"[{client.id}] {client.showname} flipped a coin and got {flip}."
-    )
+    client.area.broadcast_ooc(f"[{client.id}] {client.showname} flipped a coin and got {flip}.")
     database.log_area("coinflip", client, client.area, message=flip)
 
 
@@ -577,9 +492,9 @@ def ooc_cmd_rps(client, arg):
 
     rps_rules = client.area.area_manager.rps_rules
 
-    # Strip the input of blank spaces on edges 
+    # Strip the input of blank spaces on edges
     arg = arg.strip()
-    
+
     # If doing /rps by itself, simply tell the user the rules.
     if not arg:
         msg = "RPS rules:"
@@ -588,16 +503,18 @@ def ooc_cmd_rps(client, arg):
             choice = rule[0]
             msg += choice
             if len(choice) > 1:
-                losers = ', '.join(rule[1:])
+                losers = ", ".join(rule[1:])
                 msg += f" beats {losers}"
         client.send_ooc(msg)
         return
 
     if arg.lower() in ["clear", "cancel"]:
         if client.rps_choice:
-            client.area.broadcast_ooc(f'[{client.id}] {client.showname} no longer wants to play 🎲Rock Paper Scissors🎲... 🙁')
+            client.area.broadcast_ooc(
+                f"[{client.id}] {client.showname} no longer wants to play 🎲Rock Paper Scissors🎲... 🙁"
+            )
         client.rps_choice = ""
-        client.send_ooc('You cleared your choice.')
+        client.send_ooc("You cleared your choice.")
         return
 
     # List of our available choices
@@ -615,16 +532,16 @@ def ooc_cmd_rps(client, arg):
         # Fuzzy match, queue up our pick but look if we can get something better
         if arg.lower() in choice:
             picked = choice
-    
+
     if picked not in choices:
         raise ArgumentError(f"Invalid choice! Available choices are: {', '.join(choices)}")
-    
+
     # If we already have made a rps choice before, simply silently swap our choice.
     if client.rps_choice:
         client.rps_choice = picked
-        client.send_ooc(f'Swapped your choice to {client.rps_choice}!')
+        client.send_ooc(f"Swapped your choice to {client.rps_choice}!")
         return
-        
+
     # Set our Rock Paper Scissors choice
     client.rps_choice = picked
 
@@ -640,16 +557,16 @@ def ooc_cmd_rps(client, arg):
 
     # Look for our opponent if none is present
     if not target:
-        msg = f'[{client.id}] {client.showname} wants to play 🎲Rock Paper Scissors🎲!\n❕ Do /rps [choice] to challenge them! ❕'
+        msg = f"[{client.id}] {client.showname} wants to play 🎲Rock Paper Scissors🎲!\n❕ Do /rps [choice] to challenge them! ❕"
         client.area.broadcast_ooc(msg)
-        client.send_ooc(f'You picked {client.rps_choice}!')
+        client.send_ooc(f"You picked {client.rps_choice}!")
         return
 
     # Start constructing our output message
-    msg = '🎲Rock Paper Scissors🎲'
-    msg += f'\n  ◽ [{target.id}] {target.showname} picks {target.rps_choice}!'
-    msg += f'\n  ◽ [{client.id}] {client.showname} picks {client.rps_choice}!'
-    
+    msg = "🎲Rock Paper Scissors🎲"
+    msg += f"\n  ◽ [{target.id}] {target.showname} picks {target.rps_choice}!"
+    msg += f"\n  ◽ [{client.id}] {client.showname} picks {client.rps_choice}!"
+
     # Calculate our winner
     a = target.rps_choice.lower()
     b = client.rps_choice.lower()
@@ -690,16 +607,16 @@ def ooc_cmd_rps_rules(client, arg):
             /rps_rules <del|remove|-> [index] - delete a rule at index
             /rps_rules <clear|clean|reset|wipe> - wipe all current rules
     """
-    #client.area.area_manager.rps_rules
+    # client.area.area_manager.rps_rules
 
-    # Strip the input of blank spaces on edges 
+    # Strip the input of blank spaces on edges
     arg = arg.strip()
-    
+
     # If doing /rps_rules by itself, simply tell the user the rules.
     if not arg:
         ooc_cmd_rps(client, "")
         return
-    
+
     try:
         args = arg.split(maxsplit=1)
         action = args[0]
@@ -715,24 +632,18 @@ def ooc_cmd_rps_rules(client, arg):
                 client.area.area_manager.rps_rules.append(newrule)
                 client.send_ooc(f"Added a new rule: {rule}")
         elif action.lower() in ["del", "remove", "-"]:
-            index = int(param)-1
+            index = int(param) - 1
             if index < 0 or index >= len(client.area.area_manager.rps_rules):
-                raise ArgumentError(
-                    "Invalid index!"
-                )
+                raise ArgumentError("Invalid index!")
             client.send_ooc(f"Deleted a rule: {client.area.area_manager.rps_rules[index]}")
             client.area.area_manager.rps_rules.pop(index)
         elif action.lower() in ["clear", "clean", "reset", "wipe"]:
             client.send_ooc("Deleted all rules.")
             client.area.area_manager.rps_rules.clear()
         else:
-            raise ArgumentError(
-                "Invalid action!"
-            )
+            raise ArgumentError("Invalid action!")
     except ValueError:
-        raise ArgumentError(
-            "Invalid parameter!"
-        )
+        raise ArgumentError("Invalid parameter!")
 
 
 def ooc_cmd_timer(client, arg):
@@ -789,8 +700,7 @@ def ooc_cmd_timer(client, arg):
     if len(args) < 2:
         if timer.set:
             if timer.started:
-                client.send_ooc(
-                    f"Timer {timer_id} is at {timer.target - arrow.get()}")
+                client.send_ooc(f"Timer {timer_id} is at {timer.target - arrow.get()}")
             else:
                 client.send_ooc(f"Timer {timer_id} is at {timer.static}")
         else:
@@ -798,15 +708,9 @@ def ooc_cmd_timer(client, arg):
         return
 
     if not (client in client.area.owners) and not client.is_mod:
-        raise ArgumentError(
-            "Only CMs or GMs can modify timers. Usage: /timer <id>")
-    if (
-        timer_id == 0
-        and not (client in client.area.area_manager.owners)
-        and not client.is_mod
-    ):
-        raise ArgumentError(
-            "Only GMs can set hub-wide timer ID 0. Usage: /timer <id>")
+        raise ArgumentError("Only CMs or GMs can modify timers. Usage: /timer <id>")
+    if timer_id == 0 and not (client in client.area.area_manager.owners) and not client.is_mod:
+        raise ArgumentError("Only GMs can set hub-wide timer ID 0. Usage: /timer <id>")
 
     command_arg = args[1]
 
@@ -870,10 +774,9 @@ def ooc_cmd_timer(client, arg):
 
         cmd = full.split(" ")[0]
         from server.commands import resolve_command
+
         if resolve_command(client.server, cmd) is None:
-            client.send_ooc(
-                f"[Timer {timer_id}] Invalid command: {cmd}. Use /help to find up-to-date commands."
-            )
+            client.send_ooc(f"[Timer {timer_id}] Invalid command: {cmd}. Use /help to find up-to-date commands.")
             return
         timer.commands.append(full)
         client.send_ooc(f"Adding command to Timer {timer_id}: /{full}")
@@ -896,6 +799,7 @@ def ooc_cmd_timer(client, arg):
             timer.hub = client.area.area_manager
 
         from server.timer import start_schedule
+
         start_schedule(timer)
 
 
@@ -927,8 +831,7 @@ def ooc_cmd_demo(client, arg):
     client.last_demo_call = time.time() * 1000
     for c in client.area.clients:
         if c in client.area.owners:
-            c.send_ooc(
-                f"Starting demo playback using evidence '{evidence.name}'...")
+            c.send_ooc(f"Starting demo playback using evidence '{evidence.name}'...")
 
     client.area.play_demo(client, evidence)
 
@@ -998,8 +901,7 @@ def ooc_cmd_trigger(client, arg):
         if not evidence:
             raise ArgumentError("Target evidence not found!")
         if len(args) <= 2:
-            client.send_ooc(
-                f'Call "{evidence.triggers[trig]}" on trigger "{trig}"')
+            client.send_ooc(f'Call "{evidence.triggers[trig]}" on trigger "{trig}"')
             return
         val = args[2]
         evidence.triggers[trig] = val
@@ -1010,8 +912,7 @@ def ooc_cmd_trigger(client, arg):
         if trig not in client.area.triggers:
             raise ArgumentError(f"Invalid trigger: {trig}")
         if len(args) <= 1:
-            client.send_ooc(
-                f'Call "{client.area.triggers[trig]}" on trigger "{trig}"')
+            client.send_ooc(f'Call "{client.area.triggers[trig]}" on trigger "{trig}"')
             return
         val = args[1]
         client.area.triggers[trig] = val
@@ -1037,16 +938,12 @@ def ooc_cmd_format_timer(client, arg):
             client.send_ooc("You cannot change timer 0 format if you are not GM")
             return
     else:
-        if (
-            client.is_mod
-            or client in client.area.area_manager.owners
-            or client in client.area.owners
-        ):
+        if client.is_mod or client in client.area.area_manager.owners or client in client.area.owners:
             timer = client.area.timers[args[0] - 1]
         else:
             client.send_ooc("You cannot change timer format if you are at least CM")
             return
-    timer.format = ' '.join(args[1:])
+    timer.format = " ".join(args[1:])
     if timer.format == "":
         timer.format = "hh:mm:ss.zzz"
         client.send_ooc("Resetting timer format to default.")
@@ -1082,18 +979,14 @@ def ooc_cmd_timer_interval(client, arg):
             client.send_ooc("You cannot change timer 0 interval if you are not GM")
             return
     else:
-        if (
-            client.is_mod
-            or client in client.area.area_manager.owners
-            or client in client.area.owners
-        ):
+        if client.is_mod or client in client.area.area_manager.owners or client in client.area.owners:
             timer = client.area.timers[args[0] - 1]
         else:
             client.send_ooc("You cannot change timer interval if you are at least CM")
             return
     try:
         if len(args) == 1:
-            timer.interval = 16 
+            timer.interval = 16
         else:
             timer.interval = pytimeparse.parse(args[1]) * 1000
     except:
@@ -1102,6 +995,7 @@ def ooc_cmd_timer_interval(client, arg):
         client.send_timer_set_interval(args[0], timer)
     client.send_ooc(f"Timer {args[0]} interval is set to '{args[1]}'")
 
+
 def ooc_cmd_ooc_actions(client, arg):
     """
     Enable or disable IC actions being broadcast to OOC as well.
@@ -1109,9 +1003,7 @@ def ooc_cmd_ooc_actions(client, arg):
     Usage: /ooc_actions [tog]
     """
     if len(arg.split()) > 1:
-        raise ArgumentError(
-            "This command can only take one argument ('on' or 'off') or no arguments at all!"
-        )
+        raise ArgumentError("This command can only take one argument ('on' or 'off') or no arguments at all!")
     if arg:
         if arg == "on":
             client.ooc_actions = True
@@ -1133,25 +1025,18 @@ def ooc_cmd_sfx(client, arg):
     Usage: /sfx <sound_path>
     """
     if arg == "":
-        raise ArgumentError(
-            "sound_path can't be empty. Usage: /sfx <sound_path>"
-        )
+        raise ArgumentError("sound_path can't be empty. Usage: /sfx <sound_path>")
     is_mod = client.is_mod or client in client.area.owners
     # Only incur cooldowns etc. on mods.
     if not is_mod:
         if client.char_id <= -1 or client.char_id == None:
-            raise ClientError(
-                "You can't play sfx when you're a spectator and not a CM/GM!"
-            )
+            raise ClientError("You can't play sfx when you're a spectator and not a CM/GM!")
         if not client.can_sfx():
-            raise ClientError(
-                "You need to wait before playing sfx again!"
-            )
+            raise ClientError("You need to wait before playing sfx again!")
     target_areas = [client.area]
     if len(client.broadcast_list) > 0 and is_mod:
         try:
-            a_list = ", ".join([str(a.id)
-                                for a in client.broadcast_list])
+            a_list = ", ".join([str(a.id) for a in client.broadcast_list])
             client.send_ooc(f"Broadcasting to areas {a_list}")
             target_areas = client.broadcast_list
         except:
@@ -1168,6 +1053,4 @@ def ooc_cmd_sfx(client, arg):
             a.send_command("MC", f"../general/{arg}", -1, "", 0, 3, 0)
             a.broadcast_ooc(f"[{client.id}] {client.showname} has played sfx '{arg}'.")
     client.set_sfx_delay()
-    database.log_area(
-        "sfx", client, client.area, message=f"has played sfx {arg}"
-    )
+    database.log_area("sfx", client, client.area, message=f"has played sfx {arg}")

--- a/server/commands/roleplay.py
+++ b/server/commands/roleplay.py
@@ -33,6 +33,7 @@ __all__ = [
     "ooc_cmd_rps_rules",
     "ooc_cmd_timer",
     "ooc_cmd_demo",
+    "ooc_cmd_stop_demo",
     "ooc_cmd_trigger",
     "ooc_cmd_format_timer",
     "ooc_cmd_timer_interval",
@@ -929,6 +930,32 @@ def ooc_cmd_demo(client, arg):
                 f"Starting demo playback using evidence '{evidence.name}'...")
 
     client.area.play_demo(client, evidence)
+
+
+@mod_only(hub_owners=True)
+def ooc_cmd_stop_demo(client, arg):
+    """
+    Stop demo playback. Stops the demo in the current area, or all demos in
+    the hub when given 'all'.
+    Usage: /stop_demo [all]
+    """
+    if arg.strip().lower() == "all":
+        hub = client.area.area_manager
+        stopped = 0
+        for area in hub.areas:
+            if area.demo_runner is not None and area.demo_runner.running:
+                area.stop_demo()
+                stopped += 1
+        hub.broadcast_ooc(
+            f"{client.showname} stopped {stopped} demo playback "
+            f"{'scripts' if stopped != 1 else 'script'} in this hub."
+        )
+        return
+    area = client.area
+    if area.demo_runner is None or not area.demo_runner.running:
+        raise ArgumentError("No demo is currently playing in this area.")
+    area.stop_demo()
+    area.broadcast_ooc(f"{client.showname} stopped the demo playback in this area.")
 
 
 @mod_only(area_owners=True)

--- a/server/commands/roleplay.py
+++ b/server/commands/roleplay.py
@@ -1,6 +1,5 @@
 import random
 
-import asyncio
 import arrow
 import time
 import datetime
@@ -10,9 +9,9 @@ import shlex
 from server import database
 from server.constants import TargetType
 from server.exceptions import ClientError, ServerError, ArgumentError
+from server.remote_client import RemoteClient
 
 from . import mod_only
-from .. import commands
 
 __all__ = [
     "ooc_cmd_roll",
@@ -869,13 +868,8 @@ def ooc_cmd_timer(client, arg):
             return
 
         cmd = full.split(" ")[0]
-        called_function = f"ooc_cmd_{cmd}"
-        if len(client.server.command_aliases) > 0 and not hasattr(
-            commands, called_function
-        ):
-            if cmd in client.server.command_aliases:
-                called_function = f"ooc_cmd_{client.server.command_aliases[cmd]}"
-        if not hasattr(commands, called_function):
+        from server.commands import resolve_command
+        if resolve_command(client.server, cmd) is None:
             client.send_ooc(
                 f"[Timer {timer_id}] Invalid command: {cmd}. Use /help to find up-to-date commands."
             )
@@ -894,18 +888,14 @@ def ooc_cmd_timer(client, arg):
             client.area.send_timer_set_time(timer_id, static_time, timer.started)
         client.send_ooc(f"Timer {timer_id} is at {timer.static}")
 
+        # Record the area/hub scope the timer belongs to. Commands added to the
+        # timer run through that area's system executor client on expiry.
+        timer.area = client.area
         if timer_id == 0:
             timer.hub = client.area.area_manager
-        else:
-            timer.area = client.area
 
-        timer.caller = client
-        if timer.schedule:
-            timer.schedule.cancel()
-        if timer.started:
-            timer.schedule = asyncio.get_running_loop().call_later(
-                int(timer.static.total_seconds()), timer.timer_expired
-            )
+        from server.timer import start_schedule
+        start_schedule(timer)
 
 
 @mod_only(area_owners=True)
@@ -933,30 +923,12 @@ def ooc_cmd_demo(client, arg):
         raise ArgumentError("Target evidence not found!")
 
     client.last_demo_call = time.time() * 1000
-    client.area.demo.clear()
-
-    desc = (
-        evidence.desc.replace("<num>", "#")
-        .replace("<and>", "&")
-        .replace("<percent>", "%")
-        .replace("<dollar>", "$")
-    )
-    packets = desc.split("%")
-    for packet in packets:
-        p_args = packet.split("#")
-        p_args[0] = p_args[0].strip()
-        if p_args[0] in ["MS", "CT", "MC", "BN", "HP", "RT", "wait", "GM", "ST"]:
-            client.area.demo += [p_args]
-        elif p_args[0].startswith("/"):  # It's a command!
-            p_args = packet.split(" ")
-            p_args[0] = p_args[0].strip()
-            client.area.demo += [p_args]
     for c in client.area.clients:
         if c in client.area.owners:
             c.send_ooc(
                 f"Starting demo playback using evidence '{evidence.name}'...")
 
-    client.area.play_demo(client)
+    client.area.play_demo(client, evidence)
 
 
 @mod_only(area_owners=True)

--- a/server/constants.py
+++ b/server/constants.py
@@ -3,6 +3,11 @@ from enum import Enum
 from enum import IntFlag
 
 
+# Reserved ipid for remote/system clients. Ensures FK constraints are satisfied
+# without polluting the database with fake connection records.
+_SYSTEM_IPID = 0
+
+
 class TargetType(Enum):
     # possible keys: ip, OOC, id, cname, ipid, hdid, afk
     IP = 0

--- a/server/evidence.py
+++ b/server/evidence.py
@@ -1,9 +1,5 @@
 import re
 
-from server import commands
-from server.exceptions import ClientError, AreaError, ArgumentError, ServerError
-from server.constants import encode_ao_packet
-
 class EvidenceList:
     """Contains a list of evidence items."""
 
@@ -54,51 +50,6 @@ class EvidenceList:
                 "editable": self.editable,
                 "triggers": self.triggers,
             }
-
-        def trigger(self, area, trig, target):
-            """Call the trigger's associated command."""
-            if target.hidden:
-                return
-
-            if len(area.owners) <= 0:
-                return
-            
-            if trig not in self.triggers:
-                return
-
-            arg = self.triggers[trig]
-            if arg == "":
-                return
-
-            # Sort through all the owners, with GMs coming first and CMs coming second
-            sorted_owners = list(area._owners) + list(area.area_manager.owners)
-
-            # Pick the owner with highest permission - game master, if one exists.
-            # This permission system may be out of wack, but it *should* be good for now
-            owner = sorted_owners[0]
-
-            arg = (
-                arg.replace("<cid>", str(target.id))
-                .replace("<showname>", target.showname)
-                .replace("<char>", target.char_name)
-            )
-            args = arg.split(" ")
-            cmd = args.pop(0).lower()
-            if len(args) > 0:
-                arg = " ".join(args)[:1024]
-            try:
-                old_area = owner.area
-                old_hub = owner.area.area_manager
-                owner.area = area
-                commands.call(owner, cmd, arg)
-                if old_area and old_area in old_hub.areas:
-                    owner.area = old_area
-            except (ClientError, AreaError, ArgumentError, ServerError) as ex:
-                owner.send_ooc(f"[Area {area.id}] {ex}")
-            except Exception as ex:
-                owner.send_ooc(
-                    f"[Area {area.id}] An internal error occurred: {ex}. Please inform the staff of the server about the issue."
-                )
 
     def __init__(self):
         self.evidences = []

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -1073,7 +1073,7 @@ class AOProtocol(asyncio.Protocol):
                     evi.pos = "all"
                     area.broadcast_evidence_list()
                 asyncio.get_running_loop().call_soon(
-                    evi.trigger, area, "present", self.client
+                    area.trigger_evidence, evi, "present", self.client
                 )
             else:
                 evidence = 0

--- a/server/remote_client.py
+++ b/server/remote_client.py
@@ -25,10 +25,7 @@ Usage:
 import time
 
 from server.client_manager import ClientManager
-
-# Reserved ipid for remote/system clients. Ensures FK constraints are satisfied
-# without polluting the database with fake connection records.
-_SYSTEM_IPID = 0
+from server.constants import _SYSTEM_IPID
 _system_ipid_seeded = False
 
 
@@ -52,12 +49,13 @@ class RemoteClient(ClientManager.Client):
     for admin panel monitoring.
     """
 
-    def __init__(self, server, is_mod=True, name="[SYSTEM]"):
+    def __init__(self, server, is_mod=True, name="[SYSTEM]", is_gm=False):
         from server import database
         _ensure_system_ipid(database._database_singleton)
         super().__init__(server, _RemoteTransport(), user_id=-1, ipid=_SYSTEM_IPID)
         self.char_id = -1
         self.is_mod = is_mod
+        self.is_gm = is_gm
         self.name = name
         self.showname = name
         self.first_joined = False
@@ -80,11 +78,15 @@ class RemoteClient(ClientManager.Client):
 
     # --- Area participation ---
 
-    def join_area(self):
+    def join_area(self, area=None):
         """Add self to area.clients and server.client_manager.clients."""
+        if area is None:
+            area = self.area
         if self._in_area:
-            return
-        area = self.area
+            if self.area == area:
+                return
+            self.leave_area()
+        self.area = area
         if self not in area.clients:
             area.clients.add(self)
         if self not in self.server.client_manager.clients:
@@ -155,7 +157,7 @@ class RemoteClient(ClientManager.Client):
                 if not char_name:
                     try:
                         char_name = self.area.area_manager.char_list[cid]
-                    except (IndexError, KeyError, AttributeError):
+                    except (IndexError, KeyError, TypeError, AttributeError):
                         pass
             entry = {
                 "type": "ic",

--- a/server/script_runner.py
+++ b/server/script_runner.py
@@ -1,0 +1,202 @@
+"""
+Script runner: the shared automation engine for demo playback.
+
+A `ScriptRunner` executes an ordered list of instructions -- `wait` delays,
+AO packets, and OOC commands -- through the area's system executor client
+(`Area.get_script_client`). Playback is non-recursive: each instruction is
+processed in its own event-loop tick, so scripts are safe to chain (`/demo`
+inside `/demo`) and can be arbitrarily long.
+
+Instruction tuples: `("wait", seconds)`, `("packet", header, args)`,
+`("command", cmd, arg)`.
+"""
+
+import asyncio
+import logging
+
+from collections import deque
+
+from server import commands
+
+logger = logging.getLogger("script")
+
+# Server->client packet headers a demo is allowed to broadcast.
+PACKET_HEADERS = ("MS", "CT", "MC", "BN", "HP", "RT", "JD", "GM", "ST")
+
+
+def parse_demo_description(desc):
+    """
+    Parse an evidence description into script instructions.
+
+    Lines are terminated by `%`. A line is either an AO packet (optionally
+    multiline, closed with `%`), a `wait#<ms>` delay, or a command starting
+    with `/`. Escaped characters (`<num>`, `<and>`, `<percent>`, `<dollar>`)
+    are unescaped before splitting.
+    """
+    desc = desc.replace("<num>", "#").replace("<and>", "&").replace("<percent>", "%").replace("<dollar>", "$")
+    instructions = []
+    for line in desc.split("%"):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("/"):
+            parts = stripped.split(" ")
+            cmd = parts.pop(0).lstrip("/").lower()
+            arg = " ".join(parts)[:1024] if parts else ""
+            instructions.append(("command", cmd, arg))
+            continue
+        fields = line.split("#")
+        header = fields[0].strip()
+        if header == "wait":
+            try:
+                seconds = float(fields[1]) / 1000 if len(fields) > 1 else 0
+            except (ValueError, IndexError):
+                seconds = 0
+            instructions.append(("wait", seconds))
+        elif header in PACKET_HEADERS:
+            instructions.append(("packet", header, tuple(fields[1:])))
+        # Unknown headers are ignored so stray text in a description can't
+        # crash playback.
+    return instructions
+
+
+class ScriptRunner:
+    """Runs a sequence of demo instructions through an executor client."""
+
+    def __init__(self, area, executor):
+        self.area = area
+        self.executor = executor
+        self.queue = deque()
+        self.schedule = None
+        self.running = False
+        self.modified_packets = set()
+
+    # --- Lifecycle ---
+
+    def start(self, instructions):
+        """Replace the current queue and begin (or restart) playback."""
+        self._replace(instructions)
+        if not self.queue:
+            self.finish()
+            return False
+        self.running = True
+        logger.info(
+            "Demo started in area %s (%d instructions)", self.area.id, len(instructions)
+        )
+        self._schedule_next(0)
+        return True
+
+    def stop(self):
+        """Stop playback and clean up."""
+        logger.info("Demo stopped in area %s", self.area.id)
+        self.finish()
+
+    def finish(self):
+        """Cancel any pending step, reset script state and modified packets."""
+        if self.schedule:
+            self.schedule.cancel()
+            self.schedule = None
+        self.running = False
+        self.queue.clear()
+        self._reset_modified_packets()
+
+    def _replace(self, instructions):
+        """Swap in a new instruction queue (used by chained `/demo` calls)."""
+        if self.schedule:
+            self.schedule.cancel()
+            self.schedule = None
+        self.queue = deque(instructions)
+
+    def _schedule_next(self, delay):
+        loop = asyncio.get_running_loop()
+        if delay > 0:
+            self.schedule = loop.call_later(delay, self.step)
+        else:
+            self.schedule = loop.call_later(0, self.step)
+
+    # --- Stepping ---
+
+    def step(self):
+        if self.schedule:
+            self.schedule.cancel()
+            self.schedule = None
+        if not self.running or not self.queue:
+            self.finish()
+            return
+        instruction = self.queue.popleft()
+        kind = instruction[0]
+        if kind == "wait":
+            logger.info("Demo wait %s in area %s", instruction[1], self.area.id)
+            self._schedule_next(instruction[1])
+            return
+        if kind == "packet":
+            logger.info("Demo packet %s in area %s", instruction[1], self.area.id)
+            self.send_packet(instruction[1], instruction[2])
+        elif kind == "command":
+            # If a chained /demo took over the queue, don't schedule another
+            # step on top of the new script. If playback was stopped by an
+            # error, don't keep stepping either.
+            if self.run_command(instruction[1], instruction[2]):
+                return
+            if not self.running:
+                return
+        self._schedule_next(0)
+
+    def send_packet(self, header, args):
+        """Broadcast an AO packet, honouring the executor's broadcast list."""
+        area_list = [self.area]
+        if len(self.executor.broadcast_list) > 0:
+            area_list = self.executor.broadcast_list
+        for area in area_list:
+            packet_args = list(args)
+            if header == "MS":
+                # If we're on narration pos, keep the same position as the
+                # last IC message, falling back to the area's first pos-lock.
+                if len(packet_args) > 5 and packet_args[5] == "":
+                    if area.last_ic_message is not None:
+                        packet_args[5] = area.last_ic_message[5]
+                    elif len(self.area.pos_lock) > 0:
+                        packet_args[5] = self.area.pos_lock[0]
+            area.send_command(header, *packet_args)
+            logger.info(
+                "Demo broadcast %s to area %s (%d clients)",
+                header,
+                area.id,
+                len(area.clients),
+            )
+        self.modified_packets.add(header)
+
+    def run_command(self, cmd, arg):
+        """
+        Run a command through the executor.
+
+        Returns True if the script was replaced by a chained `/demo` call.
+        Broadcasts errors to the area and stops playback on failure.
+        """
+        resolved = commands.resolve_command(self.executor.server, cmd)
+        if resolved is None:
+            self.area.broadcast_ooc(f"[Demo] Invalid command: {cmd}. Use /help to find up-to-date commands.")
+            self.finish()
+            return False
+        is_demo = resolved is getattr(commands, "ooc_cmd_demo", None)
+        self.executor.execute(cmd, arg)
+        for msg in self.executor.output:
+            if msg.startswith("[ERROR]"):
+                self.area.broadcast_ooc(f"[Demo] {msg}")
+                self.finish()
+                return False
+        return is_demo
+
+    # --- Cleanup ---
+
+    def _reset_modified_packets(self):
+        """Restore area state for packets the script actually modified."""
+        area = self.area
+        if area is None:
+            return
+        if "HP" in self.modified_packets:
+            area.send_command("HP", 1, area.hp_def)
+            area.send_command("HP", 2, area.hp_pro)
+        if "BN" in self.modified_packets:
+            area.send_command("BN", area.background)
+        self.modified_packets.clear()

--- a/server/script_runner.py
+++ b/server/script_runner.py
@@ -24,7 +24,8 @@ Instruction tuples:
   (`char` is a char id or quoted folder; the value may be a live path).
 
 Lines use space-separated tokens; `#` is reserved for AO packet lines. A stray
-trailing `#` on any non-packet line is tolerated (the old `#%` habit).
+trailing `#` on any non-packet line is tolerated (the old `#%` habit), and a
+`//` comment to the end of a command or instruction line is dropped.
 
 See `docs/demo_scripting.md` for the full language specification.
 """
@@ -89,18 +90,16 @@ def parse_demo_description(desc):
     space-separated tokens. A stray trailing `#` is stripped from every
     non-packet line so the old `#%` habit still works. The legacy
     `wait#<ms>` form is also accepted alongside `wait <ms>`.
+
+    A `//` comment (not inside quotes, and only when it starts a token) runs
+    to the end of a command or instruction line and is dropped; packet text
+    is content and is never touched.
     """
     desc = desc.replace("<num>", "#").replace("<and>", "&").replace("<percent>", "%").replace("<dollar>", "$")
     instructions = []
     for line in _iter_lines(desc):
         stripped = line.strip().rstrip("#").strip()
         if not stripped:
-            continue
-        if stripped.startswith("/"):
-            parts = stripped.split(" ")
-            cmd = parts.pop(0).lstrip("/").lower()
-            arg = " ".join(parts)[:1024] if parts else ""
-            instructions.append(("command", cmd, arg))
             continue
         header = stripped.split("#", 1)[0].strip()
         if header in PACKET_HEADERS:
@@ -111,6 +110,15 @@ def parse_demo_description(desc):
                 # trailing field.
                 fields = fields[:-1]
             instructions.append(("packet", header, tuple(fields[1:])))
+            continue
+        stripped = _strip_comment(stripped).strip()
+        if not stripped:
+            continue
+        if stripped.startswith("/"):
+            parts = stripped.split(" ")
+            cmd = parts.pop(0).lstrip("/").lower()
+            arg = " ".join(parts)[:1024] if parts else ""
+            instructions.append(("command", cmd, arg))
         elif header == "wait":
             # Legacy `wait#<ms>` form (`wait <ms>` is handled below).
             fields = stripped.split("#")
@@ -128,10 +136,33 @@ def parse_demo_description(desc):
     return instructions
 
 
+def _strip_comment(text):
+    """
+    Drop a trailing `//` comment from a command or instruction line.
+
+    `//` starts a comment only when it begins a token (at the start of the
+    line or after whitespace), so URLs like `http://x` survive, and only when
+    it is outside quotes, so a quoted value containing `//` is preserved.
+    """
+    quote = None
+    for i, ch in enumerate(text):
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            continue
+        if ch in "\"'":
+            quote = ch
+        elif ch == "/" and i + 1 < len(text) and text[i + 1] == "/" and (i == 0 or text[i - 1].isspace()):
+            return text[:i].rstrip()
+    return text
+
+
 def _is_packet_or_command(content):
     """True if a chunk starts a packet or slash command (ends at `%` only)."""
     stripped = content.strip()
-    return stripped.startswith("/") or stripped.split("#", 1)[0].strip() in PACKET_HEADERS
+    return (stripped.startswith("/") and not stripped.startswith("//")) or stripped.split("#", 1)[
+        0
+    ].strip() in PACKET_HEADERS
 
 
 def _iter_lines(desc):

--- a/server/script_runner.py
+++ b/server/script_runner.py
@@ -20,6 +20,8 @@ Instruction tuples:
   a structured live source such as `client[i].showname`.
 - `("concat", name, value, sep)` — append to a string variable.
 - `("rand", name, low, high)` — store a random integer in `[low, high]`.
+- `("save", char, key, value)` — persist a value into a character's data
+  (`char` is a char id or quoted folder; the value may be a live path).
 
 Lines use space-separated tokens; `#` is reserved for AO packet lines. A stray
 trailing `#` on any non-packet line is tolerated (the old `#%` habit).
@@ -35,6 +37,8 @@ import re
 from server import commands
 from server.scripting import (
     _LIVE_PATH,
+    _QUOTED,
+    _resolve_char_index,
     live_get,
     live_sources,
     resolve_value,
@@ -49,7 +53,7 @@ PACKET_HEADERS = ("MS", "CT", "MC", "BN", "HP", "RT", "JD", "GM", "ST")
 
 # First token of an instruction line (space syntax). `#` is only used on
 # packet lines.
-INSTRUCTION_KEYWORDS = ("wait", "set", "get", "concat", "if", "label", "goto", "return", "rand")
+INSTRUCTION_KEYWORDS = ("wait", "set", "get", "concat", "if", "label", "goto", "return", "rand", "save")
 
 # Symbolic spellings of the `if` operators; both forms are accepted.
 _IF_ALIASES = {"==": "eq", "!=": "ne", "<": "lt", "<=": "le", ">": "gt", ">=": "ge"}
@@ -160,6 +164,50 @@ def _iter_lines(desc):
         yield content
 
 
+def _split_save(line):
+    """
+    Split a `save <char> <key> <value...>` line into its three parts.
+
+    The char and key tokens are split quote-aware (so a quoted character
+    folder can contain spaces); the value is the verbatim remainder of the
+    line, so multi-word or quoted values are preserved exactly as written.
+    """
+    tokens = []
+    current = []
+    quote_char = None
+    value_start = 0
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if quote_char is not None:
+            current.append(ch)
+            if ch == quote_char:
+                quote_char = None
+        elif ch in "\"'":
+            quote_char = ch
+            current.append(ch)
+        elif ch.isspace():
+            if current:
+                tokens.append("".join(current))
+                current = []
+                if len(tokens) == 3:
+                    value_start = i
+                    break
+        else:
+            current.append(ch)
+        i += 1
+    if current:
+        tokens.append("".join(current))
+        value_start = n
+    if len(tokens) < 3:
+        return None
+    rest = line[value_start:].strip()
+    if not rest:
+        return None
+    return tokens[1], tokens[2], rest
+
+
 def _split_operands(text):
     """Split on whitespace, keeping quoted segments (`"..."` or `'...'`) intact."""
     tokens = []
@@ -204,6 +252,11 @@ def _parse_instruction(line):
     if kind == "concat":
         if len(parts) >= 3:
             return ("concat", parts[1], parts[2], parts[3] if len(parts) >= 4 else "")
+        return None
+    if kind == "save":
+        split = _split_save(line)
+        if split is not None:
+            return ("save", split[0], split[1], split[2])
         return None
     if kind == "if":
         if len(parts) >= 5:
@@ -346,6 +399,8 @@ class ScriptRunner:
             self._eval_concat(instruction)
         elif kind == "rand":
             self._eval_rand(instruction)
+        elif kind == "save":
+            self._eval_save(instruction)
         elif kind == "command":
             # If a chained /demo took over the queue, don't schedule another
             # step on top of the new script. If playback was stopped by an
@@ -456,6 +511,33 @@ class ScriptRunner:
             self.finish()
             return
         variables[name] = random.randint(lo, hi)
+
+    def _eval_save(self, instruction):
+        """Persist a value into a character's data and save it to disk."""
+        _, char_text, key, value_text = instruction
+        variables = getattr(self.area, "variables", {})
+        sources = live_sources(self.area)
+        try:
+            char = _resolve_char_index(char_text, self.area, variables, "Character")
+            key = resolve_value(key, {}, {}) if _QUOTED.fullmatch(key) else key
+            if _LIVE_PATH.fullmatch(value_text.strip()):
+                value = live_get(value_text, self.area, variables)
+            else:
+                try:
+                    value = resolve_value(value_text, variables, sources)
+                except ScriptingError:
+                    value = value_text
+        except ScriptingError as ex:
+            self.area.broadcast_ooc(f"[Demo] [ERROR] {ex}")
+            self.finish()
+            return
+        hub = self.area.area_manager
+        if isinstance(char, int) and not hub.is_valid_char_id(char):
+            self.area.broadcast_ooc(f"[Demo] [ERROR] Unknown character id {char}; stopping playback.")
+            self.finish()
+            return
+        hub.set_character_data(char, key, value)
+        hub.save_character_data()
 
     def send_packet(self, header, args):
         """Broadcast an AO packet, honouring the executor's broadcast list."""

--- a/server/script_runner.py
+++ b/server/script_runner.py
@@ -66,7 +66,7 @@ _IF_OPS = {
 
 # Default cap on instructions executed by one script run (config override:
 # `demo_max_steps`). Guards against runaway goto loops.
-DEFAULT_MAX_STEPS = 100000
+DEFAULT_MAX_STEPS = 1000000
 
 
 def parse_demo_description(desc):

--- a/server/script_runner.py
+++ b/server/script_runner.py
@@ -2,41 +2,94 @@
 Script runner: the shared automation engine for demo playback.
 
 A `ScriptRunner` executes an ordered list of instructions -- `wait` delays,
-AO packets, and OOC commands -- through the area's system executor client
-(`Area.get_script_client`). Playback is non-recursive: each instruction is
-processed in its own event-loop tick, so scripts are safe to chain (`/demo`
-inside `/demo`) and can be arbitrarily long.
+AO packets, OOC commands, and Turing-complete control flow -- through the
+area's system executor client (`Area.get_script_client`). Playback is
+non-recursive: each instruction is processed in its own event-loop tick, so
+scripts are safe to chain (`/demo` inside `/demo`) and can be arbitrarily long.
 
-Instruction tuples: `("wait", seconds)`, `("packet", header, args)`,
-`("command", cmd, arg)`.
+Instruction tuples:
+- `("wait", seconds)`
+- `("packet", header, args)`
+- `("command", cmd, arg)`
+- `("label", name)`, `("goto", name)`, `("return",)` — `goto` remembers
+  where it jumped from; `return` jumps back, or ends the script if it wasn't
+  called from anywhere.
+- `("if", var, op, value, target)`
+- `("set", name, expr)` / `("get", name, expr)` — store a number (expression),
+  a quoted string literal, a copy of another variable's value, or (via `get`)
+  a structured live source such as `client[i].showname`.
+- `("concat", name, value, sep)` — append to a string variable.
+- `("rand", name, low, high)` — store a random integer in `[low, high]`.
+
+Lines use space-separated tokens; `#` is reserved for AO packet lines. A stray
+trailing `#` on any non-packet line is tolerated (the old `#%` habit).
+
+See `docs/demo_scripting.md` for the full language specification.
 """
 
 import asyncio
 import logging
-
-from collections import deque
+import random
+import re
 
 from server import commands
+from server.scripting import (
+    _LIVE_PATH,
+    live_get,
+    live_sources,
+    resolve_value,
+    ScriptingError,
+    substitute_placeholders,
+)
 
 logger = logging.getLogger("script")
 
 # Server->client packet headers a demo is allowed to broadcast.
 PACKET_HEADERS = ("MS", "CT", "MC", "BN", "HP", "RT", "JD", "GM", "ST")
 
+# First token of an instruction line (space syntax). `#` is only used on
+# packet lines.
+INSTRUCTION_KEYWORDS = ("wait", "set", "get", "concat", "if", "label", "goto", "return", "rand")
+
+# Symbolic spellings of the `if` operators; both forms are accepted.
+_IF_ALIASES = {"==": "eq", "!=": "ne", "<": "lt", "<=": "le", ">": "gt", ">=": "ge"}
+
+# Comparison operators for the `if` instruction.
+_IF_OPS = {
+    "eq": lambda a, b: a == b,
+    "ne": lambda a, b: a != b,
+    "lt": lambda a, b: a < b,
+    "gt": lambda a, b: a > b,
+    "le": lambda a, b: a <= b,
+    "ge": lambda a, b: a >= b,
+}
+
+# Default cap on instructions executed by one script run (config override:
+# `demo_max_steps`). Guards against runaway goto loops.
+DEFAULT_MAX_STEPS = 100000
+
 
 def parse_demo_description(desc):
     """
     Parse an evidence description into script instructions.
 
-    Lines are terminated by `%`. A line is either an AO packet (optionally
-    multiline, closed with `%`), a `wait#<ms>` delay, or a command starting
-    with `/`. Escaped characters (`<num>`, `<and>`, `<percent>`, `<dollar>`)
-    are unescaped before splitting.
+    `%` is the line terminator for AO packets and slash commands; newlines
+    inside those are content, so multiline packets (multi-line MS text) and
+    multiline command arguments keep working. Scripting instructions (`wait`,
+    `set`, `get`, `concat`, `label`, `goto`, `return`, `if`, `rand`)
+    are terminated by `%` **or** a newline, so demos can be written with real
+    line breaks. Escaped characters (`<num>`, `<and>`, `<percent>`,
+    `<dollar>`) are unescaped before splitting.
+
+    Packet lines keep the AO `#` field separator; instruction lines use
+    space-separated tokens. A stray trailing `#` is stripped from every
+    non-packet line so the old `#%` habit still works. The legacy
+    `wait#<ms>` form is also accepted alongside `wait <ms>`.
     """
     desc = desc.replace("<num>", "#").replace("<and>", "&").replace("<percent>", "%").replace("<dollar>", "$")
     instructions = []
-    for line in desc.split("%"):
-        stripped = line.strip()
+    for line in _iter_lines(desc):
+        stripped = line.strip().rstrip("#").strip()
         if not stripped:
             continue
         if stripped.startswith("/"):
@@ -45,19 +98,128 @@ def parse_demo_description(desc):
             arg = " ".join(parts)[:1024] if parts else ""
             instructions.append(("command", cmd, arg))
             continue
-        fields = line.split("#")
-        header = fields[0].strip()
-        if header == "wait":
+        header = stripped.split("#", 1)[0].strip()
+        if header in PACKET_HEADERS:
+            fields = stripped.split("#")
+            if len(fields) > 1 and fields[-1] == "":
+                # AO demo lines end with a `#` terminator before the `%`
+                # separator (`#%`); drop it so it can't become an empty
+                # trailing field.
+                fields = fields[:-1]
+            instructions.append(("packet", header, tuple(fields[1:])))
+        elif header == "wait":
+            # Legacy `wait#<ms>` form (`wait <ms>` is handled below).
+            fields = stripped.split("#")
             try:
                 seconds = float(fields[1]) / 1000 if len(fields) > 1 else 0
             except (ValueError, IndexError):
                 seconds = 0
             instructions.append(("wait", seconds))
-        elif header in PACKET_HEADERS:
-            instructions.append(("packet", header, tuple(fields[1:])))
+        elif re.split(r"\s+", stripped, maxsplit=1)[0] in INSTRUCTION_KEYWORDS:
+            parsed = _parse_instruction(stripped)
+            if parsed is not None:
+                instructions.append(parsed)
         # Unknown headers are ignored so stray text in a description can't
         # crash playback.
     return instructions
+
+
+def _is_packet_or_command(content):
+    """True if a chunk starts a packet or slash command (ends at `%` only)."""
+    stripped = content.strip()
+    return stripped.startswith("/") or stripped.split("#", 1)[0].strip() in PACKET_HEADERS
+
+
+def _iter_lines(desc):
+    """
+    Yield description lines as strings.
+
+    Packets and slash commands end at the next `%` (newlines are content, so
+    multiline packets and command arguments are preserved). Anything else ends
+    at the next `%` or newline. A `\n` after a `%` or `%` after a newline is a
+    plain empty line and is skipped.
+    """
+    desc = desc.replace("\r\n", "\n").replace("\r", "\n")
+    chunks = re.split(r"([%\n])", desc)
+    i = 0
+    n = len(chunks)
+    while i < n:
+        content = chunks[i]
+        sep = chunks[i + 1] if i + 1 < n else None
+        i += 2
+        if not content.strip():
+            continue
+        if _is_packet_or_command(content):
+            while sep is not None and sep != "%":
+                if i < n:
+                    content += "\n" + chunks[i]
+                    sep = chunks[i + 1] if i + 1 < n else None
+                    i += 2
+                else:
+                    sep = None
+        yield content
+
+
+def _split_operands(text):
+    """Split on whitespace, keeping quoted segments (`"..."` or `'...'`) intact."""
+    tokens = []
+    current = []
+    quote_char = None
+    for ch in text:
+        if quote_char is not None:
+            current.append(ch)
+            if ch == quote_char:
+                quote_char = None
+        elif ch in "\"'":
+            quote_char = ch
+            current.append(ch)
+        elif ch.isspace():
+            if current:
+                tokens.append("".join(current))
+                current = []
+        else:
+            current.append(ch)
+    if current:
+        tokens.append("".join(current))
+    return tokens
+
+
+def _parse_instruction(line):
+    """Build an instruction tuple from a space-separated instruction line."""
+    parts = _split_operands(line)
+    kind = parts[0]
+    if kind == "wait":
+        try:
+            seconds = float(parts[1]) / 1000 if len(parts) > 1 else 0
+        except (ValueError, IndexError):
+            seconds = 0
+        return ("wait", seconds)
+    if kind in ("set", "get"):
+        # The value is the rest of the line (quotes kept); split only the
+        # first two tokens so unquoted multi-word values are preserved.
+        pieces = re.split(r"\s+", line, maxsplit=2)
+        if len(pieces) >= 3:
+            return (kind, pieces[1], pieces[2])
+        return None
+    if kind == "concat":
+        if len(parts) >= 3:
+            return ("concat", parts[1], parts[2], parts[3] if len(parts) >= 4 else "")
+        return None
+    if kind == "if":
+        if len(parts) >= 5:
+            return ("if", parts[1], parts[2], parts[3], parts[4])
+        return None
+    if kind in ("label", "goto"):
+        if len(parts) >= 2:
+            return (kind, parts[1])
+        return None
+    if kind == "return":
+        return ("return",)
+    if kind == "rand":
+        if len(parts) >= 4:
+            return ("rand", parts[1], parts[2], parts[3])
+        return None
+    return None
 
 
 class ScriptRunner:
@@ -66,9 +228,17 @@ class ScriptRunner:
     def __init__(self, area, executor):
         self.area = area
         self.executor = executor
-        self.queue = deque()
+        # Instructions are kept as a list with an explicit index so scripts
+        # can jump backwards (loops) via goto -- a deque can't.
+        self.instructions = []
+        self.index = 0
+        self.labels = {}
+        self.stack = []
         self.schedule = None
         self.running = False
+        self.steps = 0
+        config = getattr(getattr(executor, "server", None), "config", None) or {}
+        self.max_steps = int(config.get("demo_max_steps", DEFAULT_MAX_STEPS))
         self.modified_packets = set()
 
     # --- Lifecycle ---
@@ -76,13 +246,12 @@ class ScriptRunner:
     def start(self, instructions):
         """Replace the current queue and begin (or restart) playback."""
         self._replace(instructions)
-        if not self.queue:
+        if not self.instructions:
             self.finish()
             return False
         self.running = True
-        logger.info(
-            "Demo started in area %s (%d instructions)", self.area.id, len(instructions)
-        )
+        self.steps = 0
+        logger.info("Demo started in area %s (%d instructions)", self.area.id, len(instructions))
         self._schedule_next(0)
         return True
 
@@ -97,7 +266,11 @@ class ScriptRunner:
             self.schedule.cancel()
             self.schedule = None
         self.running = False
-        self.queue.clear()
+        self.instructions = []
+        self.index = 0
+        self.labels = {}
+        self.stack = []
+        self.steps = 0
         self._reset_modified_packets()
 
     def _replace(self, instructions):
@@ -105,7 +278,17 @@ class ScriptRunner:
         if self.schedule:
             self.schedule.cancel()
             self.schedule = None
-        self.queue = deque(instructions)
+        self.instructions = list(instructions)
+        self.index = 0
+        self.stack = []
+        self.labels = self._build_labels(self.instructions)
+
+    def _build_labels(self, instructions):
+        labels = {}
+        for i, instruction in enumerate(instructions):
+            if instruction[0] == "label" and len(instruction) >= 2:
+                labels[instruction[1]] = i
+        return labels
 
     def _schedule_next(self, delay):
         loop = asyncio.get_running_loop()
@@ -120,10 +303,16 @@ class ScriptRunner:
         if self.schedule:
             self.schedule.cancel()
             self.schedule = None
-        if not self.running or not self.queue:
+        if not self.running or self.index >= len(self.instructions):
             self.finish()
             return
-        instruction = self.queue.popleft()
+        self.steps += 1
+        if self.steps > self.max_steps:
+            self.area.broadcast_ooc(f"[Demo] [ERROR] Max steps exceeded ({self.max_steps}); " "stopping playback.")
+            self.finish()
+            return
+        instruction = self.instructions[self.index]
+        self.index += 1
         kind = instruction[0]
         if kind == "wait":
             logger.info("Demo wait %s in area %s", instruction[1], self.area.id)
@@ -132,6 +321,31 @@ class ScriptRunner:
         if kind == "packet":
             logger.info("Demo packet %s in area %s", instruction[1], self.area.id)
             self.send_packet(instruction[1], instruction[2])
+        elif kind == "label":
+            # No-op: labels exist only as goto targets.
+            pass
+        elif kind == "goto":
+            # Like the old `call`: remember where we jumped from so `return`
+            # can come back to it.
+            self.stack.append(self.index)
+            self._jump(instruction[1])
+        elif kind == "return":
+            if self.stack:
+                self.index = self.stack.pop()
+            else:
+                # Nothing to return to -- the script is simply done.
+                self.finish()
+                return
+        elif kind == "if":
+            self._eval_if(instruction)
+        elif kind == "set":
+            self._eval_set(instruction, sources=False)
+        elif kind == "get":
+            self._eval_set(instruction, sources=True)
+        elif kind == "concat":
+            self._eval_concat(instruction)
+        elif kind == "rand":
+            self._eval_rand(instruction)
         elif kind == "command":
             # If a chained /demo took over the queue, don't schedule another
             # step on top of the new script. If playback was stopped by an
@@ -140,15 +354,124 @@ class ScriptRunner:
                 return
             if not self.running:
                 return
+        if not self.running:
+            return
         self._schedule_next(0)
+
+    def _jump(self, label):
+        """Set the instruction index to a label; errors stop playback."""
+        if label not in self.labels:
+            self.area.broadcast_ooc(f"[Demo] [ERROR] Unknown label '{label}'; stopping playback.")
+            self.finish()
+            return False
+        self.index = self.labels[label]
+        return True
+
+    def _resolve_operand(self, text, variables, sources):
+        """Resolve an operand, allowing structured live paths (get-style)."""
+        if _LIVE_PATH.fullmatch(text.strip()):
+            return live_get(text, self.area, variables)
+        return resolve_value(text, variables, sources)
+
+    def _eval_if(self, instruction):
+        """Evaluate `if <left> <op> <right> <target>` and branch on the result."""
+        _, var, op, value, target = instruction
+        op = _IF_ALIASES.get(op, op)
+        if op not in _IF_OPS:
+            self.area.broadcast_ooc(f"[Demo] [ERROR] Unknown comparison '{op}'; stopping playback.")
+            self.finish()
+            return
+        variables = getattr(self.area, "variables", {})
+        sources = live_sources(self.area)
+        try:
+            left = self._resolve_operand(var, variables, sources)
+            right = self._resolve_operand(value, variables, sources)
+        except ScriptingError as ex:
+            self.area.broadcast_ooc(f"[Demo] [ERROR] {ex}")
+            self.finish()
+            return
+        if op in ("lt", "gt", "le", "ge") and isinstance(left, str) != isinstance(right, str):
+            self.area.broadcast_ooc("[Demo] [ERROR] Cannot compare a number and a string; stopping playback.")
+            self.finish()
+            return
+        if _IF_OPS[op](left, right):
+            self._jump(target)
+
+    def _eval_set(self, instruction, sources):
+        """Evaluate an operand (or live path) and store it in an area variable."""
+        _, name, expr = instruction
+        variables = getattr(self.area, "variables", {})
+        try:
+            if sources:
+                value = self._resolve_operand(expr, variables, live_sources(self.area))
+            else:
+                value = resolve_value(expr, variables)
+        except ScriptingError as ex:
+            self.area.broadcast_ooc(f"[Demo] [ERROR] {ex}")
+            self.finish()
+            return
+        variables[name] = value
+
+    def _eval_concat(self, instruction):
+        """Append a value to a string variable, inserting the separator first."""
+        _, name, value, *rest = instruction
+        sep = rest[0] if rest else ""
+        variables = getattr(self.area, "variables", {})
+        sources = live_sources(self.area)
+        try:
+            resolved = self._resolve_operand(value, variables, sources)
+            resolved_sep = self._resolve_operand(sep, variables, sources) if sep.strip() else ""
+        except ScriptingError as ex:
+            self.area.broadcast_ooc(f"[Demo] [ERROR] {ex}")
+            self.finish()
+            return
+        current = str(variables.get(name, ""))
+        addition = f"{resolved_sep}{resolved}" if current else str(resolved)
+        variables[name] = current + addition
+
+    def _eval_rand(self, instruction):
+        """Store a random integer in `[low, high]` (inclusive) into a variable."""
+        _, name, low, high = instruction
+        variables = getattr(self.area, "variables", {})
+        sources = live_sources(self.area)
+        try:
+            lo = self._resolve_operand(low, variables, sources)
+            hi = self._resolve_operand(high, variables, sources)
+        except ScriptingError as ex:
+            self.area.broadcast_ooc(f"[Demo] [ERROR] {ex}")
+            self.finish()
+            return
+        if (
+            isinstance(lo, bool)
+            or not isinstance(lo, (int, float))
+            or isinstance(hi, bool)
+            or not isinstance(hi, (int, float))
+        ):
+            self.area.broadcast_ooc("[Demo] [ERROR] rand bounds must be numbers; stopping playback.")
+            self.finish()
+            return
+        lo, hi = int(lo), int(hi)
+        if lo > hi:
+            self.area.broadcast_ooc(f"[Demo] [ERROR] rand min {lo} is greater than max {hi}; stopping playback.")
+            self.finish()
+            return
+        variables[name] = random.randint(lo, hi)
 
     def send_packet(self, header, args):
         """Broadcast an AO packet, honouring the executor's broadcast list."""
         area_list = [self.area]
         if len(self.executor.broadcast_list) > 0:
             area_list = self.executor.broadcast_list
+        variables = getattr(self.area, "variables", {})
+        try:
+            packet_args = [
+                substitute_placeholders(str(arg), variables, live_sources(self.area), self.area) for arg in args
+            ]
+        except ScriptingError as ex:
+            self.area.broadcast_ooc(f"[Demo] [ERROR] {ex}")
+            self.finish()
+            return
         for area in area_list:
-            packet_args = list(args)
             if header == "MS":
                 # If we're on narration pos, keep the same position as the
                 # last IC message, falling back to the area's first pos-lock.
@@ -179,6 +502,13 @@ class ScriptRunner:
             self.finish()
             return False
         is_demo = resolved is getattr(commands, "ooc_cmd_demo", None)
+        variables = getattr(self.area, "variables", {})
+        try:
+            arg = substitute_placeholders(arg, variables, live_sources(self.area), self.area)
+        except ScriptingError as ex:
+            self.area.broadcast_ooc(f"[Demo] [ERROR] {ex}")
+            self.finish()
+            return False
         self.executor.execute(cmd, arg)
         for msg in self.executor.output:
             if msg.startswith("[ERROR]"):

--- a/server/scripting.py
+++ b/server/scripting.py
@@ -13,12 +13,13 @@ literals, bare identifiers copy their stored value (number or string), and
 anything else is evaluated as an arithmetic expression.
 
 `live_get` is the structured live-state resolver used by `get` and inline
-getters: `clients.count`, `client[i].<field>`, `area.<field>`, `hub.<field>`,
-`timer[i].<field>`, `evidence[i].<field>`, and `links[i].<field>`. One regex
-describes the path grammar; the source name is then looked up in the
-`_LIVE_SOURCES` registry, and every field is read through an explicit
-whitelist -- never raw `getattr`. Each indexed list is a deterministic
-snapshot (clients in `/getarea` order, evidence and links in their own order).
+getters: `clients.count`, `client[i].<field>`, `afk[i].<field>`,
+`timer[i].<field>`, `evidence[i].<field>`, `links[i].<field>`,
+`char[<name>].<key>`, `area.<field>`, and `hub.<field>`. One regex describes
+the path grammar; the source name is then looked up in the `_LIVE_SOURCES`
+registry, and every field is read through an explicit whitelist -- never raw
+`getattr`. Each indexed list is a deterministic snapshot (clients in
+`/getarea` order, evidence and links in their own order).
 """
 
 import re
@@ -164,7 +165,19 @@ _CLIENT_FIELDS = {
     "subtheme": lambda c, a: c.subtheme,
     "time_of_day": lambda c, a: c.time_of_day,
     "char_url": lambda c, a: c.char_url,
+    "hidden_in": lambda c, a: c.hidden_in if getattr(c, "hidden_in", None) is not None else "",
+    "listen_pos": lambda c, a: _listen_pos_str(c),
 }
+
+
+def _listen_pos_str(client):
+    """The position(s) a client is listening to ("" while listening normally)."""
+    value = getattr(client, "listen_pos", None)
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return " ".join(str(p) for p in value)
+    return str(value)
 
 
 def _client_char_folder(client, area):
@@ -306,9 +319,9 @@ def _hub_field(hub, field):
     raise ScriptingError(f"Unknown hub field '{field}'.")
 
 
-# Whitelisted evidence-item fields. `hiding_client` is deliberately excluded:
-# who is hiding inside which piece of evidence is a privacy leak, not a script
-# read, and `triggers` is a dict rather than a scalar.
+# Whitelisted evidence-item fields. `hiding` is the showname of whoever is
+# hiding inside the evidence ("" when empty); the raw `hiding_client` object and
+# the `triggers` dict are not exposed as scalars.
 _EVIDENCE_FIELDS = {
     "name": lambda e: e.name,
     "desc": lambda e: e.desc,
@@ -318,6 +331,7 @@ _EVIDENCE_FIELDS = {
     "show_in_dark": lambda e: e.show_in_dark,
     "can_take": lambda e: int(e.can_take),
     "editable": lambda e: int(e.editable),
+    "hiding": lambda e: getattr(getattr(e, "hiding_client", None), "showname", "") or "",
 }
 
 
@@ -400,6 +414,19 @@ def _client_item(area, index):
     return clients[index]
 
 
+def _visible_afkers(area):
+    """AFK clients in the area excluding system/executor clients."""
+    return [c for c in getattr(area, "afkers", ()) or () if getattr(c, "ipid", -1) != _SYSTEM_IPID]
+
+
+def _afk_item(area, index):
+    """The AFK client at a 0-based index (in the area's AFK order)."""
+    afkers = _visible_afkers(area)
+    if not 0 <= index < len(afkers):
+        raise ScriptingError(f"AFK index {index} out of range (0 to {len(afkers) - 1}).")
+    return afkers[index]
+
+
 def _resolve_index(text, area, variables, what="Client"):
     """Resolve an index like `client[i]`/`timer[i]`: a whole number, from a
     variable or expression."""
@@ -468,6 +495,40 @@ def _timer_field(timer, area, field):
     raise ScriptingError(f"Unknown timer field '{field}'.")
 
 
+def _resolve_char_index(text, area, variables, what="Character"):
+    """Resolve a character reference: an int char id or a quoted folder name."""
+    value = resolve_value(text, variables, live_sources(area))
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ScriptingError(f"Character '{text}' must be a character id or a quoted folder name.")
+    if isinstance(value, float):
+        if not value.is_integer():
+            raise ScriptingError(f"Character '{text}' is not a whole character id.")
+        value = int(value)
+    return value
+
+
+def _char_data(area, char):
+    """The character-data dict for a character id or folder name."""
+    hub = area.area_manager
+    if isinstance(char, int) and hub.is_valid_char_id(char):
+        char = hub.char_list[char]
+    return getattr(hub, "character_data", {}).get(char, {})
+
+
+def _char_data_field(data, field):
+    """Read one stored key (or the special `count`/`fields` reads)."""
+    if field == "count":
+        return len(data)
+    if field == "fields":
+        return " ".join(data)
+    value = data.get(field, "")
+    if isinstance(value, list):
+        return " ".join(str(v) for v in value)
+    return value
+
+
 # The live-source registry. Each entry describes one `name[<i>].<field>` source:
 #   - `what`  -- human name used in index error messages
 #   - `count` -- `(area) -> number of items`
@@ -503,6 +564,18 @@ _LIVE_SOURCES = {
         "get": _link_item,
         "field": lambda area, item, field: _link_item_field(item, field),
     },
+    "afk": {
+        "what": "AFK client",
+        "count": lambda area: len(_visible_afkers(area)),
+        "get": _afk_item,
+        "field": lambda area, item, field: _client_field(item, area, field),
+    },
+    "char": {
+        "what": "Character",
+        "get": _char_data,
+        "field": lambda area, item, field: _char_data_field(item, field),
+        "index": _resolve_char_index,
+    },
 }
 
 
@@ -513,14 +586,17 @@ def live_get(path, area, variables=None):
     Supported paths:
     - `clients.count`                      -- number of real clients in the area
     - `client[<i>].<field>`                -- one client's whitelisted field
+    - `afk.count` / `afk[<i>].<field>`     -- AFK clients (same fields as a person)
     - `timer[<i>].<field>`                 -- a timer's state (0 = hub-wide)
     - `evidence[<i>].<field>`              -- an evidence item's whitelisted field
     - `links[<i>].<field>`                 -- an area link's whitelisted field
+    - `char[<name>].<key>`                 -- character-data value for a character
     - `area.<field>` / `hub.<field>`       -- whitelisted area/hub properties
 
     `<i>` is resolved as an operand (a bare variable or an arithmetic
-    expression). Evidence and link indexes are 0-based in their stored order.
-    Unknown paths/fields and out-of-range indexes raise `ScriptingError`.
+    expression); `<name>` may be a quoted character folder or a char id.
+    Evidence, link and AFK indexes are 0-based in their stored order. Unknown
+    paths/fields and out-of-range indexes raise `ScriptingError`.
     """
     if variables is None:
         variables = {}
@@ -531,7 +607,7 @@ def live_get(path, area, variables=None):
     count_name = match.group("count")
     if count_name is not None:
         source = _LIVE_SOURCES.get(count_name)
-        if source is None:
+        if source is None or "count" not in source:
             raise ScriptingError(f"Unknown source '{path}'.")
         return source["count"](area)
     src = match.group("src")
@@ -539,7 +615,8 @@ def live_get(path, area, variables=None):
         source = _LIVE_SOURCES.get(src)
         if source is None:
             raise ScriptingError(f"Unknown source '{path}'.")
-        index = _resolve_index(match.group("idx"), area, variables, source["what"])
+        resolve_index = source.get("index", _resolve_index)
+        index = resolve_index(match.group("idx"), area, variables, source["what"])
         item = source["get"](area, index)
         return source["field"](area, item, match.group("field"))
     if match.group("scope") == "area":

--- a/server/scripting.py
+++ b/server/scripting.py
@@ -14,10 +14,11 @@ anything else is evaluated as an arithmetic expression.
 
 `live_get` is the structured live-state resolver used by `get` and inline
 getters: `clients.count`, `client[i].<field>`, `area.<field>`, `hub.<field>`,
-`timer[i].<field>`, `evidence[i].<field>`, and `links[i].<field>`. Every field
-is read through an explicit whitelist, never raw `getattr`, and each indexed
-list is a deterministic snapshot (clients in `/getarea` order, evidence and
-links in their own order).
+`timer[i].<field>`, `evidence[i].<field>`, and `links[i].<field>`. One regex
+describes the path grammar; the source name is then looked up in the
+`_LIVE_SOURCES` registry, and every field is read through an explicit
+whitelist -- never raw `getattr`. Each indexed list is a deterministic
+snapshot (clients in `/getarea` order, evidence and links in their own order).
 """
 
 import re
@@ -37,29 +38,16 @@ _PLACEHOLDER = re.compile(r"<!([^>]+)>")
 # A quoted string literal, either single- or double-quoted.
 _QUOTED = re.compile(r'^(?:"([^"]*)"|\'([^\']*)\')$')
 
-# A structured live source path (see `live_get`).
+# A structured live source path (see `live_get`). One regex describes the whole
+# grammar; the source name is then looked up in `_LIVE_SOURCES`:
+#   - `<name>.count`                  -- how many of a thing there are
+#   - `<name>[<i>].<field>`           -- the i-th item's whitelisted field
+#   - `area.<field>` / `hub.<field>`  -- a single object's whitelisted field
 _LIVE_PATH = re.compile(
-    r"^(clients\.count"
-    r"|evidence\.count"
-    r"|links\.count"
-    r"|client\[[^\]]+\]\.[A-Za-z_][A-Za-z0-9_]*"
-    r"|timer\[[^\]]+\]\.[A-Za-z_][A-Za-z0-9_]*"
-    r"|evidence\[[^\]]+\]\.[A-Za-z_][A-Za-z0-9_]*"
-    r"|links\[[^\]]+\]\.[A-Za-z_][A-Za-z0-9_]*"
-    r"|area\.[A-Za-z_][A-Za-z0-9_]*"
-    r"|hub\.[A-Za-z_][A-Za-z0-9_]*)$"
+    r"^(?:(?P<count>\w+)\.count"
+    r"|(?P<src>\w+)\[(?P<idx>[^\]]+)\]\.(?P<field>[A-Za-z_]\w*)"
+    r"|(?P<scope>area|hub)\.(?P<scopefield>[A-Za-z_]\w*))$"
 )
-
-# Client field access: `client[i].<field>`.
-_CLIENT_INDEX = re.compile(r"^client\[([^\]]+)\]\.([A-Za-z_][A-Za-z0-9_]*)$")
-# Timer field access: `timer[i].<field>`.
-_TIMER_INDEX = re.compile(r"^timer\[([^\]]+)\]\.([A-Za-z_][A-Za-z0-9_]*)$")
-# Evidence field access: `evidence[i].<field>`.
-_EVIDENCE_INDEX = re.compile(r"^evidence\[([^\]]+)\]\.([A-Za-z_][A-Za-z0-9_]*)$")
-# Link field access: `links[i].<field>`.
-_LINK_INDEX = re.compile(r"^links\[([^\]]+)\]\.([A-Za-z_][A-Za-z0-9_]*)$")
-# Area/hub field access: `area.<field>` / `hub.<field>`.
-_SCOPE_FIELD = re.compile(r"^(area|hub)\.([A-Za-z_][A-Za-z0-9_]*)$")
 
 # Maximum magnitude of any single numeric term, mirroring the `/roll` lag guard.
 MAX_TERM = 10**6
@@ -367,8 +355,8 @@ def _link_item(area, index):
     return list(links.items())[index]
 
 
-def _link_field(area, index, field):
-    target, link = _link_item(area, index)
+def _link_item_field(item, field):
+    target, link = item
     if field == "target":
         return target
     if field in _LINK_FIELDS:
@@ -402,6 +390,14 @@ def _client_snapshot(area):
     """Deterministic /getarea-ordered list of visible clients."""
     clients = _visible_clients(area)
     return sorted(sorted(clients, key=lambda c: c.showname), key=lambda c: _join_order_key(area, c))
+
+
+def _client_item(area, index):
+    """The client at a 0-based /getarea-ordered index."""
+    clients = _client_snapshot(area)
+    if not 0 <= index < len(clients):
+        raise ScriptingError(f"Client index {index} out of range (0 to {len(clients) - 1}).")
+    return clients[index]
 
 
 def _resolve_index(text, area, variables, what="Client"):
@@ -472,6 +468,44 @@ def _timer_field(timer, area, field):
     raise ScriptingError(f"Unknown timer field '{field}'.")
 
 
+# The live-source registry. Each entry describes one `name[<i>].<field>` source:
+#   - `what`  -- human name used in index error messages
+#   - `count` -- `(area) -> number of items`
+#   - `get`   -- `(area, index) -> item` (range-checked)
+#   - `field` -- `(area, item, field) -> value` (whitelisted)
+# This registry is the only place a path's source name can resolve to, so an
+# unknown source is rejected before any attribute is ever touched. `clients` is
+# the `clients.count` spelling; `client` is the singular `client[i]` spelling.
+_clients_source = {
+    "what": "Client",
+    "count": lambda area: len(_visible_clients(area)),
+    "get": _client_item,
+    "field": lambda area, item, field: _client_field(item, area, field),
+}
+_LIVE_SOURCES = {
+    "clients": _clients_source,
+    "client": _clients_source,
+    "timer": {
+        "what": "Timer",
+        "count": lambda area: len(getattr(area, "timers", ()) or ()) + 1,
+        "get": _area_timer,
+        "field": lambda area, item, field: _timer_field(item, area, field),
+    },
+    "evidence": {
+        "what": "Evidence",
+        "count": lambda area: len(getattr(getattr(area, "evi_list", None), "evidences", ()) or ()),
+        "get": _evidence_item,
+        "field": lambda area, item, field: _evidence_field(item, field),
+    },
+    "links": {
+        "what": "Link",
+        "count": lambda area: len(getattr(area, "links", {}) or {}),
+        "get": _link_item,
+        "field": lambda area, item, field: _link_item_field(item, field),
+    },
+}
+
+
 def live_get(path, area, variables=None):
     """
     Resolve a structured live-state path.
@@ -491,38 +525,26 @@ def live_get(path, area, variables=None):
     if variables is None:
         variables = {}
     path = path.strip()
-    if path == "clients.count":
-        return len(_visible_clients(area))
-    if path == "evidence.count":
-        return len(getattr(getattr(area, "evi_list", None), "evidences", ()) or ())
-    if path == "links.count":
-        return len(getattr(area, "links", {}) or {})
-    client_match = _CLIENT_INDEX.match(path)
-    if client_match:
-        index = _resolve_index(client_match.group(1), area, variables)
-        clients = _client_snapshot(area)
-        if not 0 <= index < len(clients):
-            raise ScriptingError(f"Client index {index} out of range (0 to {len(clients) - 1}).")
-        return _client_field(clients[index], area, client_match.group(2))
-    timer_match = _TIMER_INDEX.match(path)
-    if timer_match:
-        index = _resolve_index(timer_match.group(1), area, variables, "Timer")
-        return _timer_field(_area_timer(area, index), area, timer_match.group(2))
-    evidence_match = _EVIDENCE_INDEX.match(path)
-    if evidence_match:
-        index = _resolve_index(evidence_match.group(1), area, variables, "Evidence")
-        return _evidence_field(_evidence_item(area, index), evidence_match.group(2))
-    link_match = _LINK_INDEX.match(path)
-    if link_match:
-        index = _resolve_index(link_match.group(1), area, variables, "Link")
-        return _link_field(area, index, link_match.group(2))
-    scope_match = _SCOPE_FIELD.match(path)
-    if scope_match:
-        scope, field = scope_match.group(1), scope_match.group(2)
-        if scope == "area":
-            return _area_field(area, field)
-        return _hub_field(area.area_manager, field)
-    raise ScriptingError(f"Unknown source '{path}'.")
+    match = _LIVE_PATH.match(path)
+    if match is None:
+        raise ScriptingError(f"Unknown source '{path}'.")
+    count_name = match.group("count")
+    if count_name is not None:
+        source = _LIVE_SOURCES.get(count_name)
+        if source is None:
+            raise ScriptingError(f"Unknown source '{path}'.")
+        return source["count"](area)
+    src = match.group("src")
+    if src is not None:
+        source = _LIVE_SOURCES.get(src)
+        if source is None:
+            raise ScriptingError(f"Unknown source '{path}'.")
+        index = _resolve_index(match.group("idx"), area, variables, source["what"])
+        item = source["get"](area, index)
+        return source["field"](area, item, match.group("field"))
+    if match.group("scope") == "area":
+        return _area_field(area, match.group("scopefield"))
+    return _hub_field(area.area_manager, match.group("scopefield"))
 
 
 def try_live_get(path, area, variables=None):

--- a/server/scripting.py
+++ b/server/scripting.py
@@ -1,0 +1,495 @@
+"""
+Safe arithmetic expression evaluation for demo scripting.
+
+Standardizes the math engine behind `/roll` modifiers and the demo `set`/`get`
+instructions: one whitelist, one set of error messages, one security posture.
+
+Expressions support numbers, `+ - * / ( )`, and bare identifiers that are
+substituted from the caller's variable/source dictionaries. Everything else is
+rejected before evaluation, and `eval` runs with no builtins available.
+
+`resolve_value` is the general operand resolver: quoted strings become string
+literals, bare identifiers copy their stored value (number or string), and
+anything else is evaluated as an arithmetic expression.
+
+`live_get` is the structured live-state resolver used by `get` and inline
+getters: `clients.count`, `client[i].<field>`, `area.<field>`, `hub.<field>`,
+`timer[i].<field>`. Every field is read through an explicit whitelist, never
+raw `getattr`, and `client[i]` indexes a deterministic `/getarea`-ordered
+snapshot.
+"""
+
+import re
+
+from server.constants import _SYSTEM_IPID
+from server.exceptions import ArgumentError
+
+# Characters allowed in an expression after identifier substitution.
+ALLOWED_CHARS = "0123456789+-*/(). "
+
+# A bare identifier: a variable or source name to substitute with its value.
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+# An inline getter: `<!name>` (or `<!path>`) substituted with a value.
+_PLACEHOLDER = re.compile(r"<!([^>]+)>")
+
+# A quoted string literal, either single- or double-quoted.
+_QUOTED = re.compile(r'^(?:"([^"]*)"|\'([^\']*)\')$')
+
+# A structured live source path (see `live_get`).
+_LIVE_PATH = re.compile(
+    r"^(clients\.count"
+    r"|client\[[^\]]+\]\.[A-Za-z_][A-Za-z0-9_]*"
+    r"|timer\[[^\]]+\]\.[A-Za-z_][A-Za-z0-9_]*"
+    r"|area\.[A-Za-z_][A-Za-z0-9_]*"
+    r"|hub\.[A-Za-z_][A-Za-z0-9_]*)$"
+)
+
+# Client field access: `client[i].<field>`.
+_CLIENT_INDEX = re.compile(r"^client\[([^\]]+)\]\.([A-Za-z_][A-Za-z0-9_]*)$")
+# Timer field access: `timer[i].<field>`.
+_TIMER_INDEX = re.compile(r"^timer\[([^\]]+)\]\.([A-Za-z_][A-Za-z0-9_]*)$")
+# Area/hub field access: `area.<field>` / `hub.<field>`.
+_SCOPE_FIELD = re.compile(r"^(area|hub)\.([A-Za-z_][A-Za-z0-9_]*)$")
+
+# Maximum magnitude of any single numeric term, mirroring the `/roll` lag guard.
+MAX_TERM = 10**6
+
+
+class ScriptingError(ArgumentError):
+    """Raised when a scripting expression cannot be evaluated."""
+
+
+class DivisionByZeroError(ScriptingError):
+    """Raised when an expression divides by zero (so callers can retry)."""
+
+
+def evaluate_expression(expr, variables=None, sources=None):
+    """
+    Evaluate an arithmetic expression with variable substitution.
+
+    `variables` and `sources` are dicts of name -> number. Identifiers in the
+    expression are replaced with their values; any identifier that isn't
+    present raises a `ScriptingError`. Returns a number (int or float).
+    """
+    if variables is None:
+        variables = {}
+    if sources is None:
+        sources = {}
+    expr = expr.strip()
+    if not expr:
+        raise ScriptingError("Empty expression.")
+    if "**" in expr:
+        raise ScriptingError("Exponentiation is not allowed in expressions.")
+
+    def _substitute(match):
+        name = match.group(0)
+        if name in variables:
+            return str(variables[name])
+        if name in sources:
+            return str(sources[name])
+        raise ScriptingError(f"Unknown variable '{name}' in expression.")
+
+    substituted = _IDENTIFIER.sub(_substitute, expr)
+
+    for ch in substituted:
+        if ch not in ALLOWED_CHARS:
+            raise ScriptingError("Expected numbers and standard mathematical operations in expression")
+
+    # Prevent any term from reaching past MAX_TERM to avoid server lag from
+    # frivolous expressions.
+    terms = substituted
+    for op in "+-*/()":
+        terms = terms.replace(op, "!")
+    for term in terms.split("!"):
+        if term == "":
+            continue
+        try:
+            if abs(round(float(term))) > MAX_TERM:
+                raise ScriptingError("Expression takes numbers past the server's computation limit")
+        except ValueError:
+            raise ScriptingError("Expression has a syntax error and cannot be computed")
+
+    try:
+        return eval(substituted, {"__builtins__": {}}, {})
+    except ZeroDivisionError:
+        raise DivisionByZeroError("Expression divides by zero.")
+    except (SyntaxError, TypeError, NameError):
+        raise ScriptingError("Expression has a syntax error and cannot be computed")
+
+
+def resolve_value(text, variables=None, sources=None):
+    """
+    Resolve an operand to a value (number or string).
+
+    A quoted string (`"..."` or `'...'`) becomes a string literal. A bare
+    identifier that names a variable or source copies its stored value, so
+    `set b a` copies `a` whether it holds a number or a string. Anything else
+    is evaluated as an arithmetic expression and yields a number.
+    """
+    if variables is None:
+        variables = {}
+    if sources is None:
+        sources = {}
+    text = text.strip()
+    quoted = _QUOTED.match(text)
+    if quoted:
+        return quoted.group(1) if quoted.group(1) is not None else quoted.group(2)
+    if _IDENTIFIER.fullmatch(text):
+        if text in variables:
+            return variables[text]
+        if text in sources:
+            return sources[text]
+        raise ScriptingError(f"Unknown variable '{text}'.")
+    return evaluate_expression(text, variables, sources)
+
+
+# Whitelisted client fields (keys are what scripts write; values are read-only).
+_CLIENT_FIELDS = {
+    "id": lambda c, a: c.id,
+    "char_id": lambda c, a: c.char_id,
+    "char_name": lambda c, a: c.char_name,
+    "showname": lambda c, a: c.showname,
+    "name": lambda c, a: c.name,
+    "pos": lambda c, a: c.pos,
+    "pair": lambda c, a: c.charid_pair,
+    "is_cm": lambda c, a: int(c in a._owners),
+    "is_gm": lambda c, a: int(c in a.area_manager.owners),
+    "is_owner": lambda c, a: int(c in a.owners),
+    "is_afk": lambda c, a: int(c in a.afkers),
+    "hidden": lambda c, a: int(c.hidden),
+    "blinded": lambda c, a: int(c.blinded),
+    "sneaking": lambda c, a: int(c.sneaking),
+    "frozen": lambda c, a: int(c.frozen),
+    "iniswap": lambda c, a: c.iniswap,
+    "last_move_time": lambda c, a: c.last_move_time,
+    "remote_listen": lambda c, a: c.remote_listen,
+    "subtheme": lambda c, a: c.subtheme,
+    "time_of_day": lambda c, a: c.time_of_day,
+    "char_url": lambda c, a: c.char_url,
+}
+
+
+def _client_char_folder(client, area):
+    """The client's character folder, mirroring /getarea's derivation."""
+    char_id = client.char_id
+    if char_id is None or char_id < 0 or char_id >= len(area.area_manager.char_list):
+        return "Spectator"
+    return area.area_manager.char_list[char_id]
+
+
+def _client_field(client, area, field):
+    if field == "char_folder":
+        return _client_char_folder(client, area)
+    if field in _CLIENT_FIELDS:
+        return _CLIENT_FIELDS[field](client, area)
+    raise ScriptingError(f"Unknown client field '{field}'.")
+
+
+# Whitelisted area fields.
+_AREA_FIELDS = {
+    # Identity & description
+    "name": lambda a: a.name,
+    "id": lambda a: a.id,
+    "abbreviation": lambda a: a.abbreviation,
+    "desc": lambda a: a.desc,
+    "status": lambda a: a.status,
+    "doc": lambda a: a.doc,
+    # Background, overlay & position
+    "background": lambda a: a.background,
+    "background_dark": lambda a: a.background_dark,
+    "background_suffix": lambda a: a.background_suffix,
+    "overlay": lambda a: a.overlay,
+    "pos_lock": lambda a: " ".join(a.pos_lock),
+    "bg_lock": lambda a: int(a.bg_lock),
+    "overlay_lock": lambda a: int(a.overlay_lock),
+    "pos_dark": lambda a: a.pos_dark,
+    "desc_dark": lambda a: a.desc_dark,
+    "dark": lambda a: int(a.dark),
+    # Permissions & behavior
+    "can_cm": lambda a: int(a.can_cm),
+    "locking_allowed": lambda a: int(a.locking_allowed),
+    "iniswap_allowed": lambda a: int(a.iniswap_allowed),
+    "showname_changes_allowed": lambda a: int(a.showname_changes_allowed),
+    "shouts_allowed": lambda a: int(a.shouts_allowed),
+    "non_int_pres_only": lambda a: int(a.non_int_pres_only),
+    "evidence_mod": lambda a: a.evidence_mod,
+    "blankposting_allowed": lambda a: int(a.blankposting_allowed),
+    "blankposting_forced": lambda a: int(a.blankposting_forced),
+    "ooc_actions_enabled": lambda a: int(a.ooc_actions_enabled),
+    "present_reveals_evidence": lambda a: int(a.present_reveals_evidence),
+    "passing_msg": lambda a: int(a.passing_msg),
+    "can_whisper": lambda a: int(a.can_whisper),
+    "can_wtce": lambda a: int(a.can_wtce),
+    "can_change_status": lambda a: int(a.can_change_status),
+    "can_spectate": lambda a: int(a.can_spectate),
+    "can_getarea": lambda a: int(a.can_getarea),
+    "use_backgrounds_yaml": lambda a: int(a.use_backgrounds_yaml),
+    "hide_clients": lambda a: int(a.hide_clients),
+    "force_sneak": lambda a: int(a.force_sneak),
+    "locked": lambda a: int(a.locked),
+    "muted": lambda a: int(a.muted),
+    "password": lambda a: a.password,
+    "hidden": lambda a: int(a.hidden),
+    "max_players": lambda a: a.max_players,
+    "hp_def": lambda a: a.hp_def,
+    "hp_pro": lambda a: a.hp_pro,
+    "move_delay": lambda a: a.move_delay,
+    "msg_delay": lambda a: a.msg_delay,
+    "medieval_mode": lambda a: int(a.medieval_mode),
+    # Music
+    "music": lambda a: a.music,
+    "music_autoplay": lambda a: int(a.music_autoplay),
+    "music_looping": lambda a: a.music_looping,
+    "music_effects": lambda a: a.music_effects,
+    "music_ref": lambda a: a.music_ref,
+    "replace_music": lambda a: int(a.replace_music),
+    "client_music": lambda a: int(a.client_music),
+    "ambience": lambda a: a.ambience,
+    "can_dj": lambda a: int(a.can_dj),
+    "jukebox": lambda a: int(a.jukebox),
+    "music_locked": lambda a: int(a.music_locked),
+    # Minigames
+    "can_battle": lambda a: int(a.can_battle),
+    "auto_pair": lambda a: int(a.auto_pair),
+    "auto_pair_max": lambda a: a.auto_pair_max,
+    "auto_pair_cycle": lambda a: int(a.auto_pair_cycle),
+    "can_cross_swords": lambda a: int(a.can_cross_swords),
+    "can_scrum_debate": lambda a: int(a.can_scrum_debate),
+    "can_panic_talk_action": lambda a: int(a.can_panic_talk_action),
+    "cross_swords_song_start": lambda a: a.cross_swords_song_start,
+    "cross_swords_song_end": lambda a: a.cross_swords_song_end,
+    "cross_swords_song_concede": lambda a: a.cross_swords_song_concede,
+    "scrum_debate_song_start": lambda a: a.scrum_debate_song_start,
+    "scrum_debate_song_end": lambda a: a.scrum_debate_song_end,
+    "scrum_debate_song_concede": lambda a: a.scrum_debate_song_concede,
+    "panic_talk_action_song_start": lambda a: a.panic_talk_action_song_start,
+    "panic_talk_action_song_end": lambda a: a.panic_talk_action_song_end,
+    "panic_talk_action_song_concede": lambda a: a.panic_talk_action_song_concede,
+}
+
+
+def _area_field(area, field):
+    if field in _AREA_FIELDS:
+        return _AREA_FIELDS[field](area)
+    raise ScriptingError(f"Unknown area field '{field}'.")
+
+
+# Whitelisted hub (AreaManager) fields.
+_HUB_FIELDS = {
+    "name": lambda h: h.name,
+    "id": lambda h: h.id,
+    "abbreviation": lambda h: h.abbreviation,
+    "subtheme": lambda h: h.subtheme,
+    "time_of_day": lambda h: h.time_of_day,
+    "doc": lambda h: h.info,
+    "info": lambda h: h.info,
+    "char_count": lambda h: len(h.char_list),
+    "char_list_ref": lambda h: h.char_list_ref,
+    "music_ref": lambda h: h.music_ref,
+    "move_delay": lambda h: h.move_delay,
+    "arup_enabled": lambda h: int(h.arup_enabled),
+    "can_gm": lambda h: int(h.can_gm),
+    "single_cm": lambda h: int(h.single_cm),
+    "hide_clients": lambda h: int(h.hide_clients),
+    "replace_music": lambda h: int(h.replace_music),
+    "client_music": lambda h: int(h.client_music),
+    "max_areas": lambda h: h.max_areas,
+    "can_spectate": lambda h: int(h.can_spectate),
+    "can_getareas": lambda h: int(h.can_getareas),
+    "passing_msg": lambda h: int(h.passing_msg),
+    "autokick_to_latest_area": lambda h: int(h.autokick_to_latest_area),
+    "current_areas": lambda h: len(h.areas),
+}
+
+
+def _hub_field(hub, field):
+    if field in _HUB_FIELDS:
+        return _HUB_FIELDS[field](hub)
+    raise ScriptingError(f"Unknown hub field '{field}'.")
+
+
+def _visible_clients(area):
+    """Clients in the area excluding system/executor clients (ipid 0)."""
+    return [c for c in getattr(area, "clients", ()) if getattr(c, "ipid", -1) != _SYSTEM_IPID]
+
+
+def _join_order_key(area, client):
+    """Role/status ordering used by /getarea (see `get_area_clients`)."""
+    if client in area.afkers:
+        return 1
+    if client.hidden:
+        return 2
+    if client.char_id == -1:
+        return 3
+    if client in area._owners:
+        return 4
+    if client in area.area_manager.owners:
+        return 5
+    if client.is_mod:
+        return 6
+    return 0
+
+
+def _client_snapshot(area):
+    """Deterministic /getarea-ordered list of visible clients."""
+    clients = _visible_clients(area)
+    return sorted(sorted(clients, key=lambda c: c.showname), key=lambda c: _join_order_key(area, c))
+
+
+def _resolve_index(text, area, variables, what="Client"):
+    """Resolve an index like `client[i]`/`timer[i]`: a whole number, from a
+    variable or expression."""
+    index = resolve_value(text, variables, live_sources(area))
+    if isinstance(index, bool):
+        raise ScriptingError(f"{what} index '{text}' is not a whole number.")
+    if isinstance(index, float):
+        if not index.is_integer():
+            raise ScriptingError(f"{what} index '{text}' is not a whole number.")
+        index = int(index)
+    elif not isinstance(index, int):
+        raise ScriptingError(f"{what} index '{text}' is not a number.")
+    return index
+
+
+def _timer_remaining_ms(timer):
+    """Milliseconds left on a timer (static time if paused, 0 if unset)."""
+    if not timer.set:
+        return 0
+    if timer.started:
+        import arrow
+
+        remaining = timer.target - arrow.get()
+    else:
+        remaining = timer.static
+    if remaining is None:
+        return 0
+    return int(remaining.total_seconds()) * 1000
+
+
+def _timer_static_ms(timer):
+    """The timer's set duration in milliseconds (0 if unset)."""
+    if timer.static is None:
+        return 0
+    return int(timer.static.total_seconds()) * 1000
+
+
+# Whitelisted timer fields. Timer 0 is the hub-wide timer; timers 1-20 are the
+# area's own, matching the IDs shown by `/timer`.
+_TIMER_FIELDS = {
+    "set": lambda t, a: int(t.set),
+    "started": lambda t, a: int(t.started),
+    "remaining_ms": lambda t, a: _timer_remaining_ms(t),
+    "static_ms": lambda t, a: _timer_static_ms(t),
+}
+
+
+def _area_timer(area, index):
+    """Look up a timer by its user-facing ID (0 = hub timer, 1-20 = area)."""
+    if index == 0:
+        timer = getattr(getattr(area, "area_manager", None), "timer", None)
+        if timer is None:
+            raise ScriptingError("No hub timer available.")
+        return timer
+    if index < 0:
+        raise ScriptingError(f"Timer index {index} is not valid (use 0 to {len(getattr(area, 'timers', ()) or ())}).")
+    timers = getattr(area, "timers", ()) or ()
+    if index - 1 >= len(timers):
+        raise ScriptingError(f"Timer index {index} is out of range (0 to {len(timers)}).")
+    return timers[index - 1]
+
+
+def _timer_field(timer, area, field):
+    if field in _TIMER_FIELDS:
+        return _TIMER_FIELDS[field](timer, area)
+    raise ScriptingError(f"Unknown timer field '{field}'.")
+
+
+def live_get(path, area, variables=None):
+    """
+    Resolve a structured live-state path.
+
+    Supported paths:
+    - `clients.count`                      -- number of real clients in the area
+    - `client[<i>].<field>`                -- one client's whitelisted field
+    - `timer[<i>].<field>`                 -- a timer's state (0 = hub-wide)
+    - `area.<field>` / `hub.<field>`       -- whitelisted area/hub properties
+
+    `<i>` is resolved as an operand (a bare variable or an arithmetic
+    expression). Unknown paths/fields and out-of-range indexes raise
+    `ScriptingError`.
+    """
+    if variables is None:
+        variables = {}
+    path = path.strip()
+    if path == "clients.count":
+        return len(_visible_clients(area))
+    client_match = _CLIENT_INDEX.match(path)
+    if client_match:
+        index = _resolve_index(client_match.group(1), area, variables)
+        clients = _client_snapshot(area)
+        if not 0 <= index < len(clients):
+            raise ScriptingError(f"Client index {index} out of range (0 to {len(clients) - 1}).")
+        return _client_field(clients[index], area, client_match.group(2))
+    timer_match = _TIMER_INDEX.match(path)
+    if timer_match:
+        index = _resolve_index(timer_match.group(1), area, variables, "Timer")
+        return _timer_field(_area_timer(area, index), area, timer_match.group(2))
+    scope_match = _SCOPE_FIELD.match(path)
+    if scope_match:
+        scope, field = scope_match.group(1), scope_match.group(2)
+        if scope == "area":
+            return _area_field(area, field)
+        return _hub_field(area.area_manager, field)
+    raise ScriptingError(f"Unknown source '{path}'.")
+
+
+def try_live_get(path, area, variables=None):
+    """Return a live value for `path` if it is a live source path, else None."""
+    if variables is None:
+        variables = {}
+    if _LIVE_PATH.fullmatch(path.strip()):
+        return live_get(path, area, variables)
+    return None
+
+
+def substitute_placeholders(text, variables=None, sources=None, area=None):
+    """
+    Replace inline `<!name>` getters with variable/source/live values.
+
+    A placeholder resolves to a variable first, then a scalar live source, then
+    (when `area` is given) a structured live path such as `<!client[0].showname>`
+    or `<!area.background>`. Unknown names raise a `ScriptingError`. Values are
+    stringified, so numeric counters interpolate directly into packet text and
+    command arguments.
+    """
+    if variables is None:
+        variables = {}
+    if sources is None:
+        sources = {}
+
+    def _replace(match):
+        name = match.group(1)
+        if name in variables:
+            return str(variables[name])
+        if name in sources:
+            return str(sources[name])
+        if area is not None:
+            value = try_live_get(name, area, variables)
+            if value is not None:
+                return str(value)
+        raise ScriptingError(f"Unknown variable '{name}' in inline getter.")
+
+    return _PLACEHOLDER.sub(_replace, text)
+
+
+def live_sources(area):
+    """Live server state exposed to scripts as pseudo-variables."""
+    sources = {
+        "players": len(_visible_clients(area)),
+        "max_players": getattr(area, "max_players", 0),
+        "hp_def": getattr(area, "hp_def", 0),
+        "hp_pro": getattr(area, "hp_pro", 0),
+        "char_count": len(getattr(getattr(area, "area_manager", None), "char_list", ())),
+    }
+    return sources

--- a/server/scripting.py
+++ b/server/scripting.py
@@ -14,9 +14,10 @@ anything else is evaluated as an arithmetic expression.
 
 `live_get` is the structured live-state resolver used by `get` and inline
 getters: `clients.count`, `client[i].<field>`, `area.<field>`, `hub.<field>`,
-`timer[i].<field>`. Every field is read through an explicit whitelist, never
-raw `getattr`, and `client[i]` indexes a deterministic `/getarea`-ordered
-snapshot.
+`timer[i].<field>`, `evidence[i].<field>`, and `links[i].<field>`. Every field
+is read through an explicit whitelist, never raw `getattr`, and each indexed
+list is a deterministic snapshot (clients in `/getarea` order, evidence and
+links in their own order).
 """
 
 import re
@@ -39,8 +40,12 @@ _QUOTED = re.compile(r'^(?:"([^"]*)"|\'([^\']*)\')$')
 # A structured live source path (see `live_get`).
 _LIVE_PATH = re.compile(
     r"^(clients\.count"
+    r"|evidence\.count"
+    r"|links\.count"
     r"|client\[[^\]]+\]\.[A-Za-z_][A-Za-z0-9_]*"
     r"|timer\[[^\]]+\]\.[A-Za-z_][A-Za-z0-9_]*"
+    r"|evidence\[[^\]]+\]\.[A-Za-z_][A-Za-z0-9_]*"
+    r"|links\[[^\]]+\]\.[A-Za-z_][A-Za-z0-9_]*"
     r"|area\.[A-Za-z_][A-Za-z0-9_]*"
     r"|hub\.[A-Za-z_][A-Za-z0-9_]*)$"
 )
@@ -49,6 +54,10 @@ _LIVE_PATH = re.compile(
 _CLIENT_INDEX = re.compile(r"^client\[([^\]]+)\]\.([A-Za-z_][A-Za-z0-9_]*)$")
 # Timer field access: `timer[i].<field>`.
 _TIMER_INDEX = re.compile(r"^timer\[([^\]]+)\]\.([A-Za-z_][A-Za-z0-9_]*)$")
+# Evidence field access: `evidence[i].<field>`.
+_EVIDENCE_INDEX = re.compile(r"^evidence\[([^\]]+)\]\.([A-Za-z_][A-Za-z0-9_]*)$")
+# Link field access: `links[i].<field>`.
+_LINK_INDEX = re.compile(r"^links\[([^\]]+)\]\.([A-Za-z_][A-Za-z0-9_]*)$")
 # Area/hub field access: `area.<field>` / `hub.<field>`.
 _SCOPE_FIELD = re.compile(r"^(area|hub)\.([A-Za-z_][A-Za-z0-9_]*)$")
 
@@ -309,6 +318,64 @@ def _hub_field(hub, field):
     raise ScriptingError(f"Unknown hub field '{field}'.")
 
 
+# Whitelisted evidence-item fields. `hiding_client` is deliberately excluded:
+# who is hiding inside which piece of evidence is a privacy leak, not a script
+# read, and `triggers` is a dict rather than a scalar.
+_EVIDENCE_FIELDS = {
+    "name": lambda e: e.name,
+    "desc": lambda e: e.desc,
+    "image": lambda e: e.image,
+    "pos": lambda e: e.pos,
+    "can_hide_in": lambda e: int(e.can_hide_in),
+    "show_in_dark": lambda e: e.show_in_dark,
+    "can_take": lambda e: int(e.can_take),
+    "editable": lambda e: int(e.editable),
+}
+
+
+def _evidence_item(area, index):
+    """The evidence item at a 0-based index (the AO list order)."""
+    evidences = getattr(getattr(area, "evi_list", None), "evidences", ()) or ()
+    if not 0 <= index < len(evidences):
+        raise ScriptingError(f"Evidence index {index} out of range (0 to {len(evidences) - 1}).")
+    return evidences[index]
+
+
+def _evidence_field(evidence, field):
+    if field in _EVIDENCE_FIELDS:
+        return _EVIDENCE_FIELDS[field](evidence)
+    raise ScriptingError(f"Unknown evidence field '{field}'.")
+
+
+# Whitelisted link fields. A link is the dict stored under `area.links[str(target)]`.
+# The `evidence` list is returned space-joined so scripts can read it as a scalar.
+_LINK_FIELDS = {
+    "locked": lambda l: int(l.get("locked", False)),
+    "hidden": lambda l: int(l.get("hidden", False)),
+    "target_pos": lambda l: l.get("target_pos", ""),
+    "can_peek": lambda l: int(l.get("can_peek", True)),
+    "evidence": lambda l: " ".join(str(e) for e in l.get("evidence", ())),
+    "password": lambda l: l.get("password", ""),
+}
+
+
+def _link_item(area, index):
+    """The link dict at a 0-based index (creation order) plus its target."""
+    links = getattr(area, "links", {}) or {}
+    if not 0 <= index < len(links):
+        raise ScriptingError(f"Link index {index} out of range (0 to {len(links) - 1}).")
+    return list(links.items())[index]
+
+
+def _link_field(area, index, field):
+    target, link = _link_item(area, index)
+    if field == "target":
+        return target
+    if field in _LINK_FIELDS:
+        return _LINK_FIELDS[field](link)
+    raise ScriptingError(f"Unknown link field '{field}'.")
+
+
 def _visible_clients(area):
     """Clients in the area excluding system/executor clients (ipid 0)."""
     return [c for c in getattr(area, "clients", ()) if getattr(c, "ipid", -1) != _SYSTEM_IPID]
@@ -413,17 +480,23 @@ def live_get(path, area, variables=None):
     - `clients.count`                      -- number of real clients in the area
     - `client[<i>].<field>`                -- one client's whitelisted field
     - `timer[<i>].<field>`                 -- a timer's state (0 = hub-wide)
+    - `evidence[<i>].<field>`              -- an evidence item's whitelisted field
+    - `links[<i>].<field>`                 -- an area link's whitelisted field
     - `area.<field>` / `hub.<field>`       -- whitelisted area/hub properties
 
     `<i>` is resolved as an operand (a bare variable or an arithmetic
-    expression). Unknown paths/fields and out-of-range indexes raise
-    `ScriptingError`.
+    expression). Evidence and link indexes are 0-based in their stored order.
+    Unknown paths/fields and out-of-range indexes raise `ScriptingError`.
     """
     if variables is None:
         variables = {}
     path = path.strip()
     if path == "clients.count":
         return len(_visible_clients(area))
+    if path == "evidence.count":
+        return len(getattr(getattr(area, "evi_list", None), "evidences", ()) or ())
+    if path == "links.count":
+        return len(getattr(area, "links", {}) or {})
     client_match = _CLIENT_INDEX.match(path)
     if client_match:
         index = _resolve_index(client_match.group(1), area, variables)
@@ -435,6 +508,14 @@ def live_get(path, area, variables=None):
     if timer_match:
         index = _resolve_index(timer_match.group(1), area, variables, "Timer")
         return _timer_field(_area_timer(area, index), area, timer_match.group(2))
+    evidence_match = _EVIDENCE_INDEX.match(path)
+    if evidence_match:
+        index = _resolve_index(evidence_match.group(1), area, variables, "Evidence")
+        return _evidence_field(_evidence_item(area, index), evidence_match.group(2))
+    link_match = _LINK_INDEX.match(path)
+    if link_match:
+        index = _resolve_index(link_match.group(1), area, variables, "Link")
+        return _link_field(area, index, link_match.group(2))
     scope_match = _SCOPE_FIELD.match(path)
     if scope_match:
         scope, field = scope_match.group(1), scope_match.group(2)

--- a/server/timer.py
+++ b/server/timer.py
@@ -1,0 +1,89 @@
+"""
+Unified countdown timer used by both areas and hubs.
+
+Timer 0 (hub-wide) lives on an `AreaManager`; timers 1-20 are per-area. On
+expiry the queued commands run through the area's system executor client
+(see `Area.get_script_client`) so automation no longer depends on a real
+player staying online or keeping CM/GM status.
+"""
+
+import asyncio
+import datetime
+import logging
+
+logger = logging.getLogger("timer")
+
+
+class Timer:
+    """Represents a single countdown timer with attached expiry commands."""
+
+    def __init__(self, _id, area=None, hub=None):
+        self.id = _id
+        self.area = area
+        self.hub = hub
+        self.set = False
+        self.started = False
+        self.static = None
+        self.target = None
+        self.schedule = None
+        self.commands = []
+        self.format = "hh:mm:ss.zzz"
+        self.interval = 16
+
+    @property
+    def scope(self):
+        """The hub or area this timer is bound to."""
+        return self.hub if self.hub is not None else self.area
+
+    @property
+    def label(self):
+        """User-facing timer ID string ('0' for the hub timer, else 1-20)."""
+        return "0" if self.hub is not None else str(self.id + 1)
+
+    def timer_expired(self):
+        if self.schedule:
+            self.schedule.cancel()
+            self.schedule = None
+        scope = self.scope
+        # The area or hub this timer belonged to was destroyed at some point
+        if scope is None:
+            return
+
+        self.static = datetime.timedelta(0)
+        self.started = False
+
+        scope.broadcast_ooc(f"Timer {self.label} has expired.")
+        self.call_commands()
+
+    def call_commands(self):
+        if self.area is None:
+            return
+        executor = self.area.get_script_client()
+        # We clear out the commands as we call them in order one by one
+        while len(self.commands) > 0:
+            # Take the first command in the list and run it
+            cmd_string = self.commands.pop(0)
+            parts = cmd_string.split(" ")
+            cmd = parts.pop(0).lower()
+            arg = ""
+            if len(parts) > 0:
+                arg = " ".join(parts)[:1024]
+            executor.execute(cmd, arg)
+            errors = [msg for msg in executor.output if msg.startswith("[ERROR]")]
+            if errors:
+                for msg in errors:
+                    self.area.broadcast_ooc(f"[Timer {self.label}] {msg}")
+                # Command execution critically failed somewhere. Clear out all
+                # commands so the timer doesn't keep fighting us.
+                self.commands.clear()
+                return
+
+
+def start_schedule(timer):
+    """
+    (Re)arm the timer's expiry callback if it's currently running.
+    """
+    if timer.schedule:
+        timer.schedule.cancel()
+    if timer.started:
+        timer.schedule = asyncio.get_running_loop().call_later(int(timer.static.total_seconds()), timer.timer_expired)

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -326,6 +326,9 @@ class TsuServer3:
         if "demo_rate_limit_ms" not in self.config:
             self.config["demo_rate_limit_ms"] = 1000
 
+        if "demo_max_steps" not in self.config:
+            self.config["demo_max_steps"] = 100000
+
         if "zalgo_tolerance" not in self.config:
             self.config["zalgo_tolerance"] = 3
 

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -324,10 +324,10 @@ class TsuServer3:
             }
 
         if "demo_rate_limit_ms" not in self.config:
-            self.config["demo_rate_limit_ms"] = 1000
+            self.config["demo_rate_limit_ms"] = 0
 
         if "demo_max_steps" not in self.config:
-            self.config["demo_max_steps"] = 100000
+            self.config["demo_max_steps"] = 1000000
 
         if "zalgo_tolerance" not in self.config:
             self.config["zalgo_tolerance"] = 3

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -323,6 +323,9 @@ class TsuServer3:
                 "mute_length": 0,
             }
 
+        if "demo_rate_limit_ms" not in self.config:
+            self.config["demo_rate_limit_ms"] = 1000
+
         if "zalgo_tolerance" not in self.config:
             self.config["zalgo_tolerance"] = 3
 

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -1,0 +1,740 @@
+"""Tests for the automation overhaul (triggers, timers, demo playback).
+
+The roleplay automation systems all funnel through a shared executor client
+(`Area.get_script_client`) and the `ScriptRunner` engine, so the tests below
+assert on that indirection: triggers/timers/demos must never touch a real
+player's state and must keep working with no owners present.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from server import commands
+from server.area import Area
+from server.script_runner import ScriptRunner, parse_demo_description
+from server.timer import Timer
+
+
+class FakeServer:
+    command_aliases = {}
+    char_list = []
+
+
+class FakeHubManager:
+    def __init__(self):
+        self.server = FakeServer()
+
+
+class FakeAreaManager:
+    def __init__(self):
+        self.hub_manager = FakeHubManager()
+        self.owners = set()
+        self.areas = []
+        self.char_list = ["Char0"]
+
+    @property
+    def server(self):
+        return self.hub_manager.server
+
+    def real_owners(self):
+        from server.remote_client import RemoteClient
+
+        return {o for o in self.owners if not isinstance(o, RemoteClient)}
+
+    def is_valid_char_id(self, char_id):
+        return char_id == 0
+
+    def get_character_data(self, char_id, key, default=""):
+        return default
+
+
+class FakeExecutor:
+    """Mimics RemoteClient.execute: clears output, captures calls, errors."""
+
+    def __init__(self):
+        self.server = FakeServer()
+        self.output = []
+        self.calls = []
+        self.error = None
+        self.broadcast_list = []
+
+    def execute(self, cmd, arg=""):
+        self.calls.append((cmd, arg))
+        self.output = [f"[ERROR] {self.error}"] if self.error else []
+        return self.output
+
+
+class FakeTarget:
+    hidden = False
+    is_mod = False
+    id = 42
+    showname = "Showname"
+    char_name = "Char"
+
+
+class FakeBroadcastArea:
+    """Minimal area stand-in for ScriptRunner tests (no real server needed)."""
+
+    def __init__(self):
+        self.id = 0
+        self.clients = set()
+        self.hp_def = 7
+        self.hp_pro = 8
+        self.background = "test-bg"
+        self.pos_lock = ["wit"]
+        self.last_ic_message = None
+        self.sent = []
+        self.ooc = []
+
+    def send_command(self, cmd, *args):
+        self.sent.append((cmd,) + tuple(args))
+
+    def broadcast_ooc(self, msg, exclude_list=None):
+        self.ooc.append(msg)
+
+
+@pytest.fixture
+def make_area():
+    def _make_area():
+        manager = FakeAreaManager()
+        area = Area(manager, "Test Area")
+        manager.areas.append(area)
+        return area
+
+    return _make_area
+
+
+def _spy_ooc(area):
+    messages = []
+    area.broadcast_ooc = lambda msg, exclude_list=None: messages.append(msg)
+    return messages
+
+
+# --- parse_demo_description ---
+
+
+def test_parse_demo_description_basic():
+    desc = "wait#1000%CT#narrator#hello%BN#bg1%"
+    assert parse_demo_description(desc) == [
+        ("wait", 1.0),
+        ("packet", "CT", ("narrator", "hello")),
+        ("packet", "BN", ("bg1",)),
+    ]
+
+
+def test_parse_demo_description_command():
+    assert parse_demo_description("/ct hello world%") == [
+        ("command", "ct", "hello world")
+    ]
+
+
+def test_parse_demo_description_chained_demo():
+    assert parse_demo_description("/demo 2%") == [("command", "demo", "2")]
+
+
+def test_parse_demo_description_unescapes():
+    desc = "CT#a<num>b<and>c<percent>d<dollar>e%"
+    assert parse_demo_description(desc) == [("packet", "CT", ("a", "b&c"))]
+
+
+def test_parse_demo_description_ignores_unknown_headers():
+    desc = "FOO#bar%MS#x#y%"
+    assert parse_demo_description(desc) == [("packet", "MS", ("x", "y"))]
+
+
+def test_parse_demo_description_ignores_empty_lines():
+    assert parse_demo_description("%%%") == []
+
+
+def test_parse_demo_description_commands_with_newlines():
+    """Multi-line evidence: newlines before % don't drop commands or packets."""
+    desc = "/pos_lock day%\n/bg BOTC-TownSquare%\nMS#x#y%\n/timer 0 start%\nwait#1000#%"
+    assert parse_demo_description(desc) == [
+        ("command", "pos_lock", "day"),
+        ("command", "bg", "BOTC-TownSquare"),
+        ("packet", "MS", ("x", "y")),
+        ("command", "timer", "0 start"),
+        ("wait", 1.0),
+    ]
+
+
+# --- triggers ---
+
+
+def test_join_trigger_runs_command_through_executor(make_area):
+    area = make_area()
+    area.triggers["join"] = "ct <cid> <showname> <char>"
+    executor = FakeExecutor()
+    area._script_client = executor
+
+    area.trigger("join", FakeTarget())
+
+    assert executor.calls == [("ct", "42 Showname Char")]
+
+
+def test_trigger_skips_remote_and_hidden_targets(make_area, monkeypatch):
+    area = make_area()
+    area.triggers["join"] = "ct hello"
+    executor = FakeExecutor()
+    area._script_client = executor
+
+    remote = _make_remote_client(monkeypatch)
+    hidden = FakeTarget()
+    hidden.hidden = True
+
+    area.trigger("join", remote)
+    area.trigger("join", hidden)
+
+    assert executor.calls == []
+
+
+def test_trigger_ignores_empty_command(make_area):
+    area = make_area()
+    executor = FakeExecutor()
+    area._script_client = executor
+
+    area.trigger("join", FakeTarget())
+
+    assert executor.calls == []
+
+
+def test_present_trigger_runs_command_through_executor(make_area):
+    area = make_area()
+    evidence = SimpleNamespace(triggers={"present": "ct <cid>"})
+    executor = FakeExecutor()
+    area._script_client = executor
+
+    area.trigger_evidence(evidence, "present", FakeTarget())
+
+    assert executor.calls == [("ct", "42")]
+
+
+def test_trigger_broadcasts_errors(make_area):
+    area = make_area()
+    area.triggers["join"] = "ct hello"
+    executor = FakeExecutor()
+    executor.error = "boom"
+    area._script_client = executor
+    messages = _spy_ooc(area)
+
+    area.trigger("join", FakeTarget())
+
+    assert any("[ERROR] boom" in m for m in messages)
+
+
+# --- timers ---
+
+
+def test_timer_expired_runs_commands_through_executor(make_area):
+    area = make_area()
+    executor = FakeExecutor()
+    area._script_client = executor
+    messages = _spy_ooc(area)
+    timer = Timer(0, area=area)
+    timer.commands = ["ct hello", "mc test"]
+
+    timer.timer_expired()
+
+    assert executor.calls == [("ct", "hello"), ("mc", "test")]
+    assert timer.commands == []
+    assert any("expired" in m for m in messages)
+
+
+def test_timer_expired_stops_and_clears_on_error(make_area):
+    area = make_area()
+    executor = FakeExecutor()
+    executor.error = "boom"
+    area._script_client = executor
+    messages = _spy_ooc(area)
+    timer = Timer(0, area=area)
+    timer.commands = ["ct a", "ct b"]
+
+    timer.timer_expired()
+
+    assert executor.calls == [("ct", "a")]
+    assert timer.commands == []
+    assert any("[ERROR] boom" in m for m in messages)
+
+
+# --- ScriptRunner ---
+
+
+class FakeHandle:
+    def __init__(self):
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class FakeLoop:
+    """Deterministic stand-in for asyncio loop.call_later."""
+
+    def __init__(self):
+        self.calls = []
+
+    def call_later(self, delay, callback):
+        handle = FakeHandle()
+        self.calls.append((handle, delay, callback))
+        return handle
+
+    def pop_next(self):
+        handle, delay, callback = self.calls.pop(0)
+        assert not handle.cancelled, "cancelled handle fired"
+        callback()
+
+
+@pytest.fixture
+def fake_loop(monkeypatch):
+    loop = FakeLoop()
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: loop)
+    return loop
+
+
+def test_script_runner_steps_instructions(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    instructions = [
+        ("packet", "CT", ("narrator", "hello")),
+        ("wait", 0.01),
+        ("command", "h", "world"),
+    ]
+    assert runner.start(instructions) is True
+
+    fake_loop.pop_next()  # step: broadcast the CT packet
+    assert area.sent[-1] == ("CT", "narrator", "hello")
+    assert len(fake_loop.calls) == 1
+
+    fake_loop.pop_next()  # step: consume the wait, schedule the delayed step
+    assert len(fake_loop.calls) == 1
+    assert fake_loop.calls[0][1] == 0.01
+
+    fake_loop.pop_next()  # step: run the command
+    assert executor.calls == [("h", "world")]
+
+    fake_loop.pop_next()  # step: queue exhausted, finish playback
+    assert runner.running is False
+    assert not fake_loop.calls
+
+
+def test_script_runner_stops_on_error(fake_loop, monkeypatch):
+    monkeypatch.setattr(
+        commands,
+        "resolve_command",
+        lambda server, cmd: (lambda: None),
+    )
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    executor.error = "something broke"
+    runner = ScriptRunner(area, executor)
+
+    runner.start([("command", "ct", "hi")])
+    fake_loop.pop_next()  # step: command fails -> stop playback
+
+    assert runner.running is False
+    assert any("[ERROR] something broke" in m for m in area.ooc)
+    assert not fake_loop.calls
+
+
+def test_script_runner_chained_demo_replaces_queue(fake_loop, monkeypatch):
+    monkeypatch.setattr(
+        commands,
+        "resolve_command",
+        lambda server, cmd: commands.ooc_cmd_demo if cmd == "demo" else (lambda: None),
+    )
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+
+    def _execute(cmd, arg=""):
+        executor.calls.append((cmd, arg))
+        if cmd == "demo":
+            runner.start([("packet", "CT", ("narrator", "chained"))])
+        executor.output = []
+        return executor.output
+
+    executor.execute = _execute
+    runner = ScriptRunner(area, executor)
+
+    runner.start([("command", "demo", "2")])
+    fake_loop.pop_next()  # step: chained /demo replaces the queue
+
+    assert executor.calls == [("demo", "2")]
+    assert runner.running is True
+    assert len(fake_loop.calls) == 1
+
+    fake_loop.pop_next()  # step: play the chained packet
+    assert area.sent[-1] == ("CT", "narrator", "chained")
+
+    fake_loop.pop_next()  # step: queue exhausted, finish playback
+    assert runner.running is False
+    assert not fake_loop.calls
+
+
+def test_script_runner_resets_modified_packets_on_finish():
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+
+    runner.send_packet("HP", (1, "5"))
+    runner.send_packet("BN", ("some-bg",))
+    runner.finish()
+
+    assert ("HP", 1, area.hp_def) in area.sent
+    assert ("HP", 2, area.hp_pro) in area.sent
+    assert ("BN", area.background) in area.sent
+    assert runner.modified_packets == set()
+
+
+# --- Area.play_demo / stop_demo ---
+
+
+def test_play_demo_and_stop_demo(make_area):
+    async def _run():
+        area = make_area()
+        executor = FakeExecutor()
+        area._script_client = executor
+        evidence = SimpleNamespace(desc="CT#narrator#hi%")
+
+        area.play_demo(None, evidence)
+        assert area.demo_runner is not None
+
+        area.stop_demo()
+        assert area.demo_runner.running is False
+
+    asyncio.run(_run())
+
+
+def test_play_demo_warns_out_of_range_char_id(make_area):
+    """MS packets with an out-of-range char id warn the human caller."""
+
+    async def _run():
+        area = make_area()
+        area._script_client = FakeExecutor()
+        calls = []
+        caller = SimpleNamespace(send_ooc=calls.append)
+
+        good = SimpleNamespace(
+            name="good", desc="MS#1#-#CM 1##lol#wit#0#1#0#0#0#0#0#0#3# #-1###%"
+        )
+        area.play_demo(caller, good)
+        assert calls == []
+        area.stop_demo()
+
+        bad = SimpleNamespace(
+            name="bad",
+            desc="wait#500%MS#1#-#CM 1##lol#wit#0#1#500#0#0#0#0#0#3# #-1###%",
+        )
+        area.play_demo(caller, bad)
+        assert any("char id 500" in msg for msg in calls)
+        area.stop_demo()
+
+    asyncio.run(_run())
+
+
+def test_play_demo_no_instructions_warns_executor_caller(make_area):
+    """Executor-triggered demos (present/join triggers) with no parseable
+    lines broadcast a warning to the area instead of failing silently."""
+
+    async def _run():
+        area = make_area()
+        area._script_client = FakeExecutor()
+        ooc = _spy_ooc(area)
+        evidence = SimpleNamespace(
+            name="Nominate",
+            desc="(👀Discovered in pos: wit)\njust some stray text with no % lines",
+        )
+        area.play_demo(None, evidence)
+        assert area.demo_runner is None
+        assert any("has no demo instructions" in msg for msg in ooc)
+        assert any("Nominate" in msg for msg in ooc)
+
+    asyncio.run(_run())
+
+
+def test_play_demo_warns_out_of_range_char_id_for_executor(make_area):
+    """OOR MS packets in an executor-triggered demo warn the area owners."""
+
+    async def _run():
+        area = make_area()
+        area._script_client = FakeExecutor()
+        ooc = _spy_ooc(area)
+        bad = SimpleNamespace(
+            name="bad",
+            desc="wait#500%MS#1#-#CM 1##lol#wit#0#1#500#0#0#0#0#0#3# #-1###%",
+        )
+        area.play_demo(None, bad)
+        assert any("char id 500" in msg for msg in ooc)
+        area.stop_demo()
+
+    asyncio.run(_run())
+
+
+def test_demo_broadcasts_to_real_clients(monkeypatch):
+    """End-to-end: playback on the real executor reaches real players in the area."""
+    import asyncio
+
+    import server.remote_client as remote_client
+    from server.client_manager import ClientManager
+    from server.evidence import EvidenceList
+    from server.remote_client import RemoteClient
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+
+    class RecordingTransport:
+        def __init__(self):
+            self.writes = []
+
+        def write(self, data):
+            self.writes.append(data)
+
+    server = SimpleNamespace(
+        hub_manager=FakeHubManager(),
+        config={
+            "playerlimit": 64,
+            "hostname": "test",
+            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1},
+        },
+        command_aliases={},
+    )
+    server.client_manager = ClientManager(server)
+
+    manager = FakeAreaManager()
+    manager.hub_manager.server = server
+    area = Area(manager, "Test Area")
+    manager.areas.append(area)
+
+    transport = RecordingTransport()
+    player = ClientManager.Client(server, transport, 1, 1)
+    player.char_id = 0
+    player.area = area
+    area.clients.add(player)
+
+    area.evi_list.evidences.append(
+        EvidenceList.Evidence(
+            "demo",
+            "CT#test#hello-from-demo%"
+            "MS#1#-#CM 1##lol#wit#0#1#0#0#0#0#0#0#3# #-1###%",
+            "image",
+            "all",
+        )
+    )
+
+    async def _run():
+        area.play_demo(None, area.evi_list.evidences[0])
+        await asyncio.sleep(0.05)
+
+    asyncio.run(_run())
+
+    assert isinstance(area._script_client, RemoteClient)
+    payload = b"".join(transport.writes).decode("utf-8", "replace")
+    assert "hello-from-demo" in payload
+    assert "lol" in payload
+    assert "MS#" in payload
+
+
+# --- Executor robustness regressions (live-server crashes) ---
+
+
+class FakeTransport:
+    pass
+
+
+class FakeHub:
+    def default_area(self):
+        return None
+
+
+class FakeHubManager:
+    def __init__(self):
+        self.server = FakeServer()
+
+    def default_hub(self):
+        return FakeHub()
+
+
+def _make_server():
+    return SimpleNamespace(
+        hub_manager=FakeHubManager(),
+        config={
+            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1},
+        },
+    )
+
+
+def _make_remote_client(monkeypatch):
+    import server.remote_client as remote_client
+    from server.remote_client import RemoteClient
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+    return RemoteClient(_make_server(), is_mod=True)
+
+
+def test_remote_client_excluded_from_player_list(make_area, monkeypatch):
+    """System executor must not appear in player-list broadcasts (/gm crash)."""
+    import json as json_module
+
+    from server.client_manager import ClientManager
+
+    server = _make_server()
+    real = ClientManager.Client(server, FakeTransport(), 1, 1)
+    real.char_id = 0
+    remote = _make_remote_client(monkeypatch)
+    remote.char_id = 0  # would pass every filter if not excluded by type
+
+    area = make_area()
+    area.clients = {real, remote}
+    real.area = area
+
+    sent = []
+    target = FakeTarget()
+    target.send_command = lambda cmd, *args: sent.append((cmd, args))
+
+    area.broadcast_player_list_to_target(target)
+
+    jsn = json_module.loads(sent[0][1][0])
+    assert [str(c["id"]) for c in jsn["data"]] == ["1"]
+
+
+def test_remote_client_ms_interception_tolerates_string_cid(monkeypatch):
+    """Demo MS packets carry a string cid; interception must not raise."""
+    rc = _make_remote_client(monkeypatch)
+    rc.area = SimpleNamespace(
+        id=0,
+        name="x",
+        clients=set(),
+        area_manager=SimpleNamespace(char_list=["Char0"]),
+    )
+
+    args = [str(i) for i in range(17)]
+    args[8] = "-1"
+    rc.send_command("MS", *args)  # must not raise TypeError
+
+    assert rc.area.area_manager.char_list == ["Char0"]
+
+
+def test_executor_is_gm_never_mod(monkeypatch):
+    """The system executor holds GM authority, never mod power."""
+    import server.remote_client as remote_client
+    from server.remote_client import RemoteClient
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+    executor = RemoteClient(_make_server(), is_mod=False, name="[SCRIPT]", is_gm=True)
+    assert executor.is_mod is False
+    assert executor.is_gm is True
+
+    admin = RemoteClient(_make_server(), is_mod=True, name="[ADMIN]", is_gm=False)
+    assert admin.is_mod is True
+    assert admin.is_gm is False
+
+
+def test_executor_permissions_gm_only(monkeypatch):
+    """Executor can run GM/CM commands but is denied pure-mod ones."""
+    import server.remote_client as remote_client
+    from server.client_manager import ClientManager
+    from server.remote_client import RemoteClient
+    from server.exceptions import ClientError
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+
+    server = SimpleNamespace(
+        hub_manager=FakeHubManager(),
+        config={
+            "playerlimit": 64,
+            "hostname": "test",
+            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1},
+        },
+        command_aliases={},
+    )
+    server.client_manager = ClientManager(server)
+
+    manager = FakeAreaManager()
+    manager.hub_manager.server = server
+    area = Area(manager, "Test Area")
+    manager.areas.append(area)
+
+    executor = area.get_script_client()
+    assert isinstance(executor, RemoteClient)
+    assert executor.is_mod is False
+    assert executor.is_gm is True
+
+    # The executor holds GM authority: it's in the owner sets command bodies
+    # check directly (e.g. /kick), but is invisible to real-GM lifecycle logic.
+    assert executor in area.owners
+    assert executor in area.area_manager.owners
+    assert executor not in area.area_manager.real_owners()
+
+    # GM/CM-gated command (/demo) still runs through the executor.
+    out = executor.execute("demo", "")
+    assert any("Stopping demo playback" in msg for msg in out)
+
+    # Pure-mod command (/announce) is refused, even from the executor.
+    out = executor.execute("announce", "hi")
+    assert any("must be authorized" in msg for msg in out)
+
+    # A regular client with no privileges is still denied both gates.
+    player = ClientManager.Client(server, FakeTransport(), 1, 1)
+    player.char_id = 0
+    player.area = area
+    area.clients.add(player)
+    with pytest.raises(ClientError):
+        commands.call(player, "announce", "hi")
+    with pytest.raises(ClientError):
+        commands.call(player, "demo", "")
+
+
+def test_executor_invisible_to_gm_lifecycle(monkeypatch):
+    """The phantom GM never blocks hub-name reset or shows in GM listings."""
+    import server.remote_client as remote_client
+    from server.area_manager import AreaManager
+    from server.client_manager import ClientManager
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+
+    server = SimpleNamespace(
+        hub_manager=FakeHubManager(),
+        config={
+            "playerlimit": 64,
+            "hostname": "test",
+            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1},
+        },
+        command_aliases={},
+    )
+    server.client_manager = ClientManager(server)
+
+    manager = AreaManager(server.hub_manager, "Original Hub")
+    manager.hub_manager.server = server
+    manager.broadcast_ooc = lambda *a, **k: None
+    area = Area(manager, "Test Area")
+    manager.areas.append(area)
+
+    area.get_script_client()  # creates the phantom GM
+    assert len(manager.owners) == 1
+    assert len(manager.real_owners()) == 0
+    assert manager.get_gms() == ""
+
+    gm = ClientManager.Client(server, FakeTransport(), 1, 1)
+    gm.area = area
+    gm.broadcast_list = []
+    gm.hide = lambda *a, **k: None
+    area.broadcast_area_list = lambda *a, **k: None
+    area.broadcast_evidence_list = lambda *a, **k: None
+    manager.owners.add(gm)
+
+    assert len(manager.real_owners()) == 1
+    assert manager.get_gms() == "[SYSTEM]".replace("[SYSTEM]", gm.name)
+
+    manager.name = "Meme Name"
+    manager.remove_owner(gm)
+    # Only the phantom GM remains, so the hub name must still reset.
+    assert manager.name == "Original Hub"

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -25,6 +25,7 @@ class FakeServer:
 class FakeHubManager:
     def __init__(self):
         self.server = FakeServer()
+        self.hubs = []
 
 
 class FakeAreaManager:
@@ -33,10 +34,23 @@ class FakeAreaManager:
         self.owners = set()
         self.areas = []
         self.char_list = ["Char0"]
+        self.can_gm = True
+        self.single_cm = False
+        self.arup_enabled = False
+        self.hide_clients = False
 
     @property
     def server(self):
         return self.hub_manager.server
+
+    def broadcast_ooc(self, msg, exclude_list=None):
+        pass
+
+    def send_arup_players(self):
+        pass
+
+    def update_subtheme(self, client):
+        pass
 
     def real_owners(self):
         from server.remote_client import RemoteClient
@@ -45,6 +59,9 @@ class FakeAreaManager:
 
     def is_valid_char_id(self, char_id):
         return char_id == 0
+
+    def get_area_by_id(self, area_id):
+        return self.areas[area_id]
 
     def get_character_data(self, char_id, key, default=""):
         return default
@@ -55,10 +72,14 @@ class FakeExecutor:
 
     def __init__(self):
         self.server = FakeServer()
+        self.area = None
         self.output = []
         self.calls = []
         self.error = None
         self.broadcast_list = []
+
+    def join_area(self, area):
+        self.area = area
 
     def execute(self, cmd, arg=""):
         self.calls.append((cmd, arg))
@@ -552,6 +573,7 @@ class FakeHub:
 class FakeHubManager:
     def __init__(self):
         self.server = FakeServer()
+        self.hubs = []
 
     def default_hub(self):
         return FakeHub()
@@ -670,6 +692,7 @@ def test_executor_permissions_gm_only(monkeypatch):
     # check directly (e.g. /kick), but is invisible to real-GM lifecycle logic.
     assert executor in area.owners
     assert executor in area.area_manager.owners
+    assert executor not in area._owners
     assert executor not in area.area_manager.real_owners()
 
     # GM/CM-gated command (/demo) still runs through the executor.
@@ -714,6 +737,7 @@ def test_executor_invisible_to_gm_lifecycle(monkeypatch):
 
     manager = AreaManager(server.hub_manager, "Original Hub")
     manager.hub_manager.server = server
+    manager.can_gm = True
     manager.broadcast_ooc = lambda *a, **k: None
     area = Area(manager, "Test Area")
     manager.areas.append(area)
@@ -738,3 +762,309 @@ def test_executor_invisible_to_gm_lifecycle(monkeypatch):
     manager.remove_owner(gm)
     # Only the phantom GM remains, so the hub name must still reset.
     assert manager.name == "Original Hub"
+
+
+# --- Executor authority: CM in claim-only hubs ---
+
+
+def _server_with_client_manager():
+    from server.client_manager import ClientManager
+
+    server = SimpleNamespace(
+        hub_manager=FakeHubManager(),
+        config={
+            "playerlimit": 64,
+            "hostname": "test",
+            "music_change_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "ooc_floodguard": {"interval_length": 1, "times_per_interval": 1},
+            "wtce_floodguard": {"interval_length": 1, "times_per_interval": 1},
+        },
+        command_aliases={},
+        player_state_observer=SimpleNamespace(
+            notify_hub_changed=lambda *a, **k: None,
+            notify_area_id_changed=lambda *a, **k: None,
+        ),
+    )
+    server.client_manager = ClientManager(server)
+    return server
+
+
+def test_executor_is_cm_in_claim_only_hub(monkeypatch):
+    """In a hub where GMs can't be claimed (e.g. KFO Hub 0), the executor is
+    an area owner (CM), never a hub owner (GM), so CM automation can't
+    escalate to GM power through a demo."""
+    import server.remote_client as remote_client
+    from server.remote_client import RemoteClient
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+
+    server = _server_with_client_manager()
+    manager = FakeAreaManager()
+    manager.can_gm = False
+    manager.hub_manager.server = server
+    area = Area(manager, "Test Area")
+    manager.areas.append(area)
+    manager.timer = Timer(0, area=area, hub=manager)
+
+    executor = area.get_script_client()
+    assert isinstance(executor, RemoteClient)
+    assert executor.is_mod is False
+    assert executor.is_gm is False
+    assert executor in area._owners
+    assert executor in area.owners
+    assert executor not in area.area_manager.owners
+    assert area.real_cms() == set()
+    assert area.get_owners() == ""
+
+    # CM-gated commands still run through the executor (/demo, area timers).
+    out = executor.execute("demo", "")
+    assert any("Stopping demo playback" in msg for msg in out)
+    out = executor.execute("timer", "1 5m")
+    assert any("Timer 1" in msg for msg in out)
+
+    # GM-only commands are denied, so a CM can't escalate via a demo.
+    out = executor.execute("timer", "0 5m")
+    assert any("Only GMs can set hub-wide timer ID 0" in msg for msg in out)
+    out = executor.execute("stop_demo", "")
+    assert any("must be authorized" in msg for msg in out)
+
+    # Pure-mod commands stay denied too.
+    out = executor.execute("announce", "hi")
+    assert any("must be authorized" in msg for msg in out)
+
+
+def test_get_owners_excludes_executor(monkeypatch):
+    """The phantom CM never shows up in CM listings (get_owners/ARUP)."""
+    import server.remote_client as remote_client
+    from server.client_manager import ClientManager
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+
+    server = _server_with_client_manager()
+    manager = FakeAreaManager()
+    manager.can_gm = False
+    manager.hub_manager.server = server
+    area = Area(manager, "Test Area")
+    manager.areas.append(area)
+
+    executor = area.get_script_client()
+    assert executor in area._owners
+    assert area.get_owners() == ""
+
+    cm = ClientManager.Client(server, FakeTransport(), 1, 1)
+    cm.showname = "RealCM"
+    cm.char_id = 0
+    cm.area = area
+    area._owners.add(cm)
+
+    assert area.real_cms() == {cm}
+    assert "RealCM" in area.get_owners()
+    assert "[SCRIPT]" not in area.get_owners()
+
+
+def test_executor_cannot_change_hubs(monkeypatch):
+    """The automation executor can't escape its hub/area via change_area."""
+    import server.remote_client as remote_client
+    from server.exceptions import ClientError
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+
+    server = _server_with_client_manager()
+    manager = FakeAreaManager()
+    manager.hub_manager.server = server
+    area = Area(manager, "Test Area")
+    manager.areas.append(area)
+
+    other = FakeAreaManager()
+    other.hub_manager.server = server
+    other_area = Area(other, "Other Area")
+    other.areas.append(other_area)
+
+    executor = area.get_script_client()
+    assert getattr(executor, "is_automation", False) is True
+    assert executor.area == area
+    with pytest.raises(ClientError):
+        executor.change_area(other_area)
+    assert executor.area == area
+
+
+# --- Executor movement: GM crawl vs CM pinning ---
+
+
+def test_cm_executor_cannot_leave_area(monkeypatch):
+    """A CM-level executor in a claim-only hub is pinned to its home area:
+    any set_area attempt (e.g. via /area_kick **) raises and leaves it put."""
+    import server.remote_client as remote_client
+    from server.exceptions import ClientError
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+
+    server = _server_with_client_manager()
+    manager = FakeAreaManager()
+    manager.can_gm = False
+    manager.hub_manager.server = server
+    area = Area(manager, "Test Area")
+    other = Area(manager, "Other Area")
+    manager.areas.extend([area, other])
+
+    executor = area.get_script_client()
+    assert executor.is_gm is False
+    with pytest.raises(ClientError):
+        executor.set_area(other)
+    assert executor.area is area
+    assert executor in area.clients
+    assert executor in server.client_manager.clients
+    assert executor in area._owners
+
+
+def test_gm_executor_can_crawl_within_hub(monkeypatch):
+    """A GM-level executor may move between areas of its own hub (e.g. a GM
+    /area_kick), but never leaves the hub."""
+    import server.remote_client as remote_client
+    from server.client_manager import ClientManager
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+    # set_area triggers area join/leave + music bookkeeping that isn't under test.
+    monkeypatch.setattr(Area, "new_client", lambda self, client: self.clients.add(client))
+    monkeypatch.setattr(Area, "remove_client", lambda self, client: self.clients.discard(client))
+    monkeypatch.setattr(Area, "broadcast_area_list", lambda *a, **k: None)
+    monkeypatch.setattr(Area, "broadcast_player_list", lambda *a, **k: None)
+    monkeypatch.setattr(Area, "broadcast_player_list_to_target", lambda *a, **k: None)
+    monkeypatch.setattr(ClientManager.Client, "refresh_music", lambda self, reload=False: None)
+
+    server = _server_with_client_manager()
+    manager = FakeAreaManager()
+    manager.hub_manager.server = server
+    area1 = Area(manager, "Area 1")
+    area2 = Area(manager, "Area 2")
+    manager.areas.extend([area1, area2])
+
+    executor = area1.get_script_client()
+    assert executor.is_gm is True
+    executor.set_area(area2)
+    assert executor.area is area2
+    assert executor in area2.clients
+    assert executor not in area1.clients
+    assert executor in server.client_manager.clients
+
+
+def test_gm_executor_cannot_change_hubs(monkeypatch):
+    """Even a GM-level executor cannot move to another hub via set_area."""
+    import server.remote_client as remote_client
+    from server.exceptions import ClientError
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+
+    server = _server_with_client_manager()
+    manager = FakeAreaManager()
+    manager.hub_manager.server = server
+    area1 = Area(manager, "Area 1")
+    manager.areas.append(area1)
+
+    other = FakeAreaManager()
+    other.hub_manager.server = server
+    other_area = Area(other, "Other Hub Area")
+    other.areas.append(other_area)
+
+    executor = area1.get_script_client()
+    with pytest.raises(ClientError):
+        executor.set_area(other_area)
+    assert executor.area is area1
+    assert executor in area1.clients
+
+
+def test_get_script_client_reanchors_parked_executor(monkeypatch):
+    """Reusing a cached executor that was parked in another area (e.g. via a
+    GM area_kick) pulls it back to its home area before the demo/trigger runs."""
+    import server.remote_client as remote_client
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+
+    server = _server_with_client_manager()
+    manager = FakeAreaManager()
+    manager.hub_manager.server = server
+    area1 = Area(manager, "Area 1")
+    area2 = Area(manager, "Area 2")
+    manager.areas.extend([area1, area2])
+
+    executor = area1.get_script_client()
+    assert executor in server.client_manager.clients
+
+    # GM executor crawled to another area in the same hub.
+    area1.clients.discard(executor)
+    executor.area = area2
+    area2.clients.add(executor)
+
+    assert area1.get_script_client() is executor
+    assert executor.area is area1
+    assert executor in area1.clients
+    assert executor not in area2.clients
+    assert executor in server.client_manager.clients
+
+
+# --- /stop_demo ---
+
+
+def test_stop_demo_stops_area_and_all_hub_demos(monkeypatch):
+    """GMs/mods can stop the current area demo and all hub demos via /stop_demo."""
+    import server.remote_client as remote_client
+    from server.client_manager import ClientManager
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+
+    server = _server_with_client_manager()
+    manager = FakeAreaManager()
+    manager.hub_manager.server = server
+    area1 = Area(manager, "Area 1")
+    area2 = Area(manager, "Area 2")
+    manager.areas.extend([area1, area2])
+    area1._script_client = FakeExecutor()
+    area2._script_client = FakeExecutor()
+
+    gm = ClientManager.Client(server, FakeTransport(), 1, 1)
+    gm.showname = "GM"
+    gm.char_id = 0
+    gm.area = area1
+    gm.send_command = lambda *a, **k: None
+    area1.clients.add(gm)
+    manager.owners.add(gm)
+
+    evidence = SimpleNamespace(desc="CT#narrator#hi%")
+
+    async def _run():
+        area1.play_demo(None, evidence)
+        area2.play_demo(None, evidence)
+        assert area1.demo_runner.running and area2.demo_runner.running
+
+        commands.call(gm, "stop_demo", "")
+        assert area1.demo_runner.running is False
+        assert area2.demo_runner.running is True
+
+        commands.call(gm, "stop_demo", "all")
+        assert area1.demo_runner.running is False
+        assert area2.demo_runner.running is False
+
+    asyncio.run(_run())
+
+
+def test_stop_demo_denied_for_cm(monkeypatch):
+    """CMs (area owners) can't use /stop_demo; only GMs and mods."""
+    import server.remote_client as remote_client
+    from server.client_manager import ClientManager
+    from server.exceptions import ClientError
+
+    monkeypatch.setattr(remote_client, "_ensure_system_ipid", lambda db: None)
+
+    server = _server_with_client_manager()
+    manager = FakeAreaManager()
+    manager.hub_manager.server = server
+    area = Area(manager, "Test Area")
+    manager.areas.append(area)
+
+    cm = ClientManager.Client(server, FakeTransport(), 1, 1)
+    cm.showname = "CM"
+    cm.area = area
+    area._owners.add(cm)
+
+    with pytest.raises(ClientError):
+        commands.call(cm, "stop_demo", "")

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -14,6 +14,7 @@ import pytest
 from server import commands
 from server.area import Area
 from server.evidence import EvidenceList
+from server.exceptions import ServerError
 from server.script_runner import ScriptRunner, parse_demo_description
 from server.timer import Timer
 
@@ -36,6 +37,8 @@ class FakeAreaManager:
         self.areas = []
         self.char_list = ["Char0"]
         self.name = "Test Hub"
+        self.character_data = {}
+        self.saved_paths = []
         self.abbreviation = "TH"
         self.subtheme = ""
         self.time_of_day = ""
@@ -75,13 +78,29 @@ class FakeAreaManager:
         return {o for o in self.owners if not isinstance(o, RemoteClient)}
 
     def is_valid_char_id(self, char_id):
-        return char_id == 0
+        return len(self.char_list) > char_id >= 0
 
     def get_area_by_id(self, area_id):
         return self.areas[area_id]
 
-    def get_character_data(self, char_id, key, default=""):
-        return default
+    def get_char_id_by_name(self, name):
+        for i, ch in enumerate(self.char_list):
+            if ch.lower() == name.lower():
+                return i
+        raise ServerError("Character not found.")
+
+    def get_character_data(self, char, key, default=None):
+        if isinstance(char, int) and self.is_valid_char_id(char):
+            char = self.char_list[char]
+        return self.character_data.get(char, {}).get(key, default)
+
+    def set_character_data(self, char, key, value):
+        if isinstance(char, int) and self.is_valid_char_id(char):
+            char = self.char_list[char]
+        self.character_data.setdefault(char, {})[key] = value
+
+    def save_character_data(self, path=None):
+        self.saved_paths.append(path)
 
 
 class FakeExecutor:
@@ -163,6 +182,8 @@ class FakeScriptClient:
         self.subtheme = ""
         self.time_of_day = ""
         self.char_url = ""
+        self.hidden_in = None
+        self.listen_pos = None
 
 
 @pytest.fixture
@@ -290,6 +311,13 @@ def test_parse_demo_description_concat():
     assert parse_demo_description('concat list s ", "%concat tag s%') == [
         ("concat", "list", "s", '", "'),
         ("concat", "tag", "s", ""),
+    ]
+
+
+def test_parse_demo_description_save():
+    assert parse_demo_description('save "my folder" title "hello world"%save 0 lives 3%') == [
+        ("save", '"my folder"', "title", '"hello world"'),
+        ("save", "0", "lives", "3"),
     ]
 
 
@@ -2334,3 +2362,150 @@ def test_script_runner_get_excludes_system_client(fake_loop):
 
     fake_loop.pop_next()  # queue exhausted
     assert runner.running is False
+
+
+def test_live_get_client_hidden_and_listen_fields():
+    from server.scripting import live_get
+
+    area = FakeBroadcastArea()
+    client = FakeScriptClient(1, "Miles")
+    area.clients = {client}
+    assert live_get("client[0].hidden_in", area) == ""
+    assert live_get("client[0].listen_pos", area) == ""
+    client.hidden_in = 3
+    client.listen_pos = ["wit", "stand"]
+    assert live_get("client[0].hidden_in", area) == 3
+    assert live_get("client[0].listen_pos", area) == "wit stand"
+
+
+def test_live_get_evidence_hiding_field():
+    from server.scripting import live_get
+
+    area = FakeBroadcastArea()
+    evi = EvidenceList.Evidence("Letter", "A", "", "all")
+    area.evi_list.evidences.append(evi)
+    assert live_get("evidence[0].hiding", area) == ""
+    evi.hiding_client = FakeScriptClient(1, "Miles")
+    assert live_get("evidence[0].hiding", area) == "Miles"
+
+
+def test_live_get_afk_source():
+    from server.scripting import live_get, ScriptingError
+
+    area = FakeBroadcastArea()
+    area.afkers = [FakeScriptClient(1, "Miles"), FakeScriptClient(2, "Apollo")]
+    assert live_get("afk.count", area) == 2
+    assert live_get("afk[0].showname", area) == "Miles"
+    assert live_get("afk[0].pos", area) == "wit"
+    # System clients are hidden from the AFK list too.
+    area.afkers.append(FakeScriptClient(3, "System", ipid=0))
+    assert live_get("afk.count", area) == 2
+    with pytest.raises(ScriptingError, match="AFK index"):
+        live_get("afk[2].showname", area)
+    with pytest.raises(ScriptingError):
+        live_get("afk[0].bogus_field", area)
+
+
+def test_live_get_char_source(make_area):
+    from server.scripting import live_get, ScriptingError
+
+    area = make_area()
+    hub = area.area_manager
+    hub.char_list = ["Phoenix", "Edgeworth"]
+    hub.character_data = {
+        "Phoenix": {"title": "Attorney", "points": 3, "tags": ["a", "b"]},
+        "Edgeworth": {"title": "Prosecutor"},
+    }
+    assert live_get("char[0].title", area) == "Attorney"
+    assert live_get('char["Phoenix"].title', area) == "Attorney"
+    assert live_get('char["Phoenix"].points', area) == 3
+    assert live_get('char["Phoenix"].tags', area) == "a b"
+    assert live_get('char["Phoenix"].missing', area) == ""
+    assert live_get('char["Phoenix"].count', area) == 3
+    assert live_get('char["Phoenix"].fields', area) == "title points tags"
+    assert live_get("char[1].title", area) == "Prosecutor"
+    assert live_get('char["Bogus"].anything', area) == ""
+    with pytest.raises(ScriptingError, match="Unknown source"):
+        live_get("char.count", area)
+    with pytest.raises(ScriptingError, match="Unknown source"):
+        live_get("bogus.count", area)
+    with pytest.raises(ScriptingError, match="Unknown source"):
+        live_get("bogus[0].x", area)
+    with pytest.raises(ScriptingError):
+        live_get("char[Edgeworth].title", area)
+
+
+def test_script_runner_save_char_data(fake_loop):
+    area = FakeBroadcastArea()
+    area.area_manager.char_list = ["Phoenix", "Edgeworth"]
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("save", '"Phoenix"', "title", '"Attorney"'),
+            ("save", "0", "points", "5"),
+            ("get", "got", 'char["Phoenix"].title'),
+            ("packet", "CT", ("narrator", "<!got>")),
+        ]
+    )
+    fake_loop.pop_next()  # save title
+    fake_loop.pop_next()  # save points
+    fake_loop.pop_next()  # get title from saved data
+    fake_loop.pop_next()  # broadcast CT with getter
+
+    assert area.area_manager.character_data["Phoenix"]["title"] == "Attorney"
+    assert area.area_manager.character_data["Phoenix"]["points"] == 5
+    assert area.area_manager.saved_paths == [None, None]
+    assert area.sent[-1] == ("CT", "narrator", "Attorney")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_save_unknown_char_stops(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("save", "999", "title", '"x"')])
+
+    fake_loop.pop_next()
+
+    assert any("Unknown character id 999" in m for m in area.ooc)
+    assert runner.running is False
+
+
+def test_ooc_get_set_char_data():
+    from server.commands.character import ooc_cmd_get_char_data, ooc_cmd_set_char_data
+
+    area = FakeBroadcastArea()
+    area.area_manager.char_list = ["Phoenix", "Edgeworth"]
+    out = []
+    client = SimpleNamespace(area=area, is_mod=True, send_ooc=out.append)
+
+    ooc_cmd_set_char_data(client, "0 title Attorney")
+    assert area.area_manager.character_data["Phoenix"]["title"] == "Attorney"
+    assert area.area_manager.saved_paths == [None]
+
+    ooc_cmd_get_char_data(client, "phoenix title")
+    assert any("title = Attorney" in m for m in out)
+
+    out.clear()
+    ooc_cmd_get_char_data(client, "phoenix")
+    assert any("Phoenix.title = Attorney" in m for m in out)
+
+    ooc_cmd_set_char_data(client, "phoenix title")
+    assert "title" not in area.area_manager.character_data["Phoenix"]
+    assert len(area.area_manager.saved_paths) == 2
+
+
+def test_ooc_set_char_data_unknown_char():
+    from server.commands.character import ooc_cmd_set_char_data
+    from server.exceptions import ArgumentError
+
+    area = FakeBroadcastArea()
+    area.area_manager.char_list = ["Phoenix"]
+    client = SimpleNamespace(area=area, is_mod=True, send_ooc=lambda m: None)
+    with pytest.raises(ArgumentError, match="Unknown character id"):
+        ooc_cmd_set_char_data(client, "999 title x")
+    with pytest.raises(ArgumentError, match="Unknown character"):
+        ooc_cmd_set_char_data(client, "Bogus title x")

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -321,6 +321,46 @@ def test_parse_demo_description_save():
     ]
 
 
+def test_parse_demo_description_strips_trailing_comments():
+    desc = "set count 5   // adds 1\nif count > 0 loop  // keep going\nlabel loop"
+    assert parse_demo_description(desc) == [
+        ("set", "count", "5"),
+        ("if", "count", ">", "0", "loop"),
+        ("label", "loop"),
+    ]
+
+
+def test_parse_demo_description_strips_full_line_comments():
+    desc = "// just a note\nset count 5%// another note\nset count 6"
+    assert parse_demo_description(desc) == [
+        ("set", "count", "5"),
+        ("set", "count", "6"),
+    ]
+
+
+def test_parse_demo_description_comment_on_command_line():
+    assert parse_demo_description("/demo 3 // chained demo%\nset z 1") == [
+        ("command", "demo", "3"),
+        ("set", "z", "1"),
+    ]
+
+
+def test_parse_demo_description_comment_preserved_in_packet_text():
+    """Packet `#` fields are content; a `//` inside them must survive."""
+    assert parse_demo_description("CT#narrator#Hello // world%") == [("packet", "CT", ("narrator", "Hello // world"))]
+
+
+def test_parse_demo_description_comment_preserved_in_quotes():
+    """A `//` inside a quoted value is not a comment."""
+    assert parse_demo_description('set url "http://example.com"  // a site') == [("set", "url", '"http://example.com"')]
+    assert parse_demo_description('concat path "a//b"') == [("concat", "path", '"a//b"', "")]
+
+
+def test_parse_demo_description_url_not_stripped():
+    """URLs keep their `//` when the line ends without a comment."""
+    assert parse_demo_description("set site http://example.com") == [("set", "site", "http://example.com")]
+
+
 def test_parse_demo_description_ignores_unknown_headers():
     desc = "FOO#bar%MS#x#y%"
     assert parse_demo_description(desc) == [("packet", "MS", ("x", "y"))]

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -34,10 +34,26 @@ class FakeAreaManager:
         self.owners = set()
         self.areas = []
         self.char_list = ["Char0"]
+        self.name = "Test Hub"
+        self.abbreviation = "TH"
+        self.subtheme = ""
+        self.time_of_day = ""
+        self.info = ""
+        self.char_list_ref = ""
+        self.music_ref = ""
+        self.move_delay = 0
         self.can_gm = True
         self.single_cm = False
-        self.arup_enabled = False
+        self.arup_enabled = True
         self.hide_clients = False
+        self.replace_music = False
+        self.client_music = True
+        self.max_areas = -1
+        self.can_spectate = True
+        self.can_getareas = True
+        self.passing_msg = False
+        self.autokick_to_latest_area = False
+        self.timer = Timer(0, hub=self)
 
     @property
     def server(self):
@@ -108,12 +124,42 @@ class FakeBroadcastArea:
         self.last_ic_message = None
         self.sent = []
         self.ooc = []
+        self.variables = {}
+        self.afkers = []
+        self._owners = set()
+        self.area_manager = FakeAreaManager()
+        self.timers = [Timer(x, area=self) for x in range(20)]
 
     def send_command(self, cmd, *args):
         self.sent.append((cmd,) + tuple(args))
 
     def broadcast_ooc(self, msg, exclude_list=None):
         self.ooc.append(msg)
+
+
+class FakeScriptClient:
+    """Minimal Client stand-in with the fields the live-source whitelist reads."""
+
+    def __init__(self, user_id, showname, char_id=0, ipid=1, is_mod=False, hidden=False):
+        self.id = user_id
+        self.showname = showname
+        self.char_name = showname
+        self.name = showname
+        self.char_id = char_id
+        self.ipid = ipid
+        self.is_mod = is_mod
+        self.hidden = hidden
+        self.pos = "wit"
+        self.charid_pair = -1
+        self.hdid = "hdid"
+        self.sneaking = False
+        self.frozen = False
+        self.iniswap = ""
+        self.last_move_time = 0
+        self.remote_listen = 2
+        self.subtheme = ""
+        self.time_of_day = ""
+        self.char_url = ""
 
 
 @pytest.fixture
@@ -137,7 +183,7 @@ def _spy_ooc(area):
 
 
 def test_parse_demo_description_basic():
-    desc = "wait#1000%CT#narrator#hello%BN#bg1%"
+    desc = "wait 1000%CT#narrator#hello%BN#bg1%"
     assert parse_demo_description(desc) == [
         ("wait", 1.0),
         ("packet", "CT", ("narrator", "hello")),
@@ -146,9 +192,7 @@ def test_parse_demo_description_basic():
 
 
 def test_parse_demo_description_command():
-    assert parse_demo_description("/ct hello world%") == [
-        ("command", "ct", "hello world")
-    ]
+    assert parse_demo_description("/ct hello world%") == [("command", "ct", "hello world")]
 
 
 def test_parse_demo_description_chained_demo():
@@ -158,6 +202,92 @@ def test_parse_demo_description_chained_demo():
 def test_parse_demo_description_unescapes():
     desc = "CT#a<num>b<and>c<percent>d<dollar>e%"
     assert parse_demo_description(desc) == [("packet", "CT", ("a", "b&c"))]
+
+
+def test_parse_demo_description_num_percent_terminator():
+    desc = "set count 0#%CT#COUNTER#Count: <!count>#1#%set count count+1#%if count gt 1 loop#%label loop#%return#%wait 500#%"
+    assert parse_demo_description(desc) == [
+        ("set", "count", "0"),
+        ("packet", "CT", ("COUNTER", "Count: <!count>", "1")),
+        ("set", "count", "count+1"),
+        ("if", "count", "gt", "1", "loop"),
+        ("label", "loop"),
+        ("return",),
+        ("wait", 0.5),
+    ]
+
+
+def test_parse_demo_description_symbol_if_operators():
+    desc = "if total >= 5 done%if x == 2 next%if y != z other%if a < 3 small%if b <= 2 tiny%if c > 9 big%"
+    assert parse_demo_description(desc) == [
+        ("if", "total", ">=", "5", "done"),
+        ("if", "x", "==", "2", "next"),
+        ("if", "y", "!=", "z", "other"),
+        ("if", "a", "<", "3", "small"),
+        ("if", "b", "<=", "2", "tiny"),
+        ("if", "c", ">", "9", "big"),
+    ]
+
+
+def test_parse_demo_description_rand():
+    desc = "rand roll 1 6%rand dmg 2 total+1%"
+    assert parse_demo_description(desc) == [
+        ("rand", "roll", "1", "6"),
+        ("rand", "dmg", "2", "total+1"),
+    ]
+
+
+def test_parse_demo_description_newline_separated_instructions():
+    desc = "set count 5\nset count count-1\nif count gt 0 loop\nlabel loop"
+    assert parse_demo_description(desc) == [
+        ("set", "count", "5"),
+        ("set", "count", "count-1"),
+        ("if", "count", "gt", "0", "loop"),
+        ("label", "loop"),
+    ]
+
+
+def test_parse_demo_description_newlines_and_percent_mixed():
+    desc = "set count 5\nlabel loop\nset count count-1\nif count gt 0 loop%\nCT#narrator#go%\nwait 500"
+    assert parse_demo_description(desc) == [
+        ("set", "count", "5"),
+        ("label", "loop"),
+        ("set", "count", "count-1"),
+        ("if", "count", "gt", "0", "loop"),
+        ("packet", "CT", ("narrator", "go")),
+        ("wait", 0.5),
+    ]
+
+
+def test_parse_demo_description_multiline_packet_preserved():
+    """A packet spans newlines until `%`; newlines stay in its fields."""
+    desc = "CT#narrator#Hello\nthere\nguys!!!#%\nset count 5%"
+    assert parse_demo_description(desc) == [
+        ("packet", "CT", ("narrator", "Hello\nthere\nguys!!!")),
+        ("set", "count", "5"),
+    ]
+
+
+def test_parse_demo_description_multiline_command_preserved():
+    """A slash command spans newlines until `%`; newlines stay in its args."""
+    desc = "/say line one\nline two%\nset count 5%"
+    assert parse_demo_description(desc) == [
+        ("command", "say", "line one\nline two"),
+        ("set", "count", "5"),
+    ]
+
+
+def test_parse_demo_description_wait_hash_form():
+    """Legacy `wait#<ms>#%` and space `wait <ms>` are equivalent."""
+    assert parse_demo_description("wait#5000#%") == [("wait", 5.0)]
+    assert parse_demo_description("wait 5000") == [("wait", 5.0)]
+
+
+def test_parse_demo_description_concat():
+    assert parse_demo_description('concat list s ", "%concat tag s%') == [
+        ("concat", "list", "s", '", "'),
+        ("concat", "tag", "s", ""),
+    ]
 
 
 def test_parse_demo_description_ignores_unknown_headers():
@@ -171,7 +301,7 @@ def test_parse_demo_description_ignores_empty_lines():
 
 def test_parse_demo_description_commands_with_newlines():
     """Multi-line evidence: newlines before % don't drop commands or packets."""
-    desc = "/pos_lock day%\n/bg BOTC-TownSquare%\nMS#x#y%\n/timer 0 start%\nwait#1000#%"
+    desc = "/pos_lock day%\n/bg BOTC-TownSquare%\nMS#x#y%\n/timer 0 start%\nwait 1000#%"
     assert parse_demo_description(desc) == [
         ("command", "pos_lock", "day"),
         ("command", "bg", "BOTC-TownSquare"),
@@ -243,6 +373,20 @@ def test_trigger_broadcasts_errors(make_area):
     area.trigger("join", FakeTarget())
 
     assert any("[ERROR] boom" in m for m in messages)
+
+
+def test_trigger_sets_script_context_variables(make_area):
+    area = make_area()
+    area.triggers["join"] = "ct <showname>"
+    executor = FakeExecutor()
+    area._script_client = executor
+
+    area.trigger("join", FakeTarget())
+
+    assert executor.calls == [("ct", "Showname")]
+    assert area.variables["trigger_cid"] == 42
+    assert area.variables["trigger_showname"] == "Showname"
+    assert area.variables["trigger_char"] == "Char"
 
 
 # --- timers ---
@@ -437,16 +581,14 @@ def test_play_demo_warns_out_of_range_char_id(make_area):
         calls = []
         caller = SimpleNamespace(send_ooc=calls.append)
 
-        good = SimpleNamespace(
-            name="good", desc="MS#1#-#CM 1##lol#wit#0#1#0#0#0#0#0#0#3# #-1###%"
-        )
+        good = SimpleNamespace(name="good", desc="MS#1#-#CM 1##lol#wit#0#1#0#0#0#0#0#0#3# #-1###%")
         area.play_demo(caller, good)
         assert calls == []
         area.stop_demo()
 
         bad = SimpleNamespace(
             name="bad",
-            desc="wait#500%MS#1#-#CM 1##lol#wit#0#1#500#0#0#0#0#0#3# #-1###%",
+            desc="wait 500%MS#1#-#CM 1##lol#wit#0#1#500#0#0#0#0#0#3# #-1###%",
         )
         area.play_demo(caller, bad)
         assert any("char id 500" in msg for msg in calls)
@@ -484,7 +626,7 @@ def test_play_demo_warns_out_of_range_char_id_for_executor(make_area):
         ooc = _spy_ooc(area)
         bad = SimpleNamespace(
             name="bad",
-            desc="wait#500%MS#1#-#CM 1##lol#wit#0#1#500#0#0#0#0#0#3# #-1###%",
+            desc="wait 500%MS#1#-#CM 1##lol#wit#0#1#500#0#0#0#0#0#3# #-1###%",
         )
         area.play_demo(None, bad)
         assert any("char id 500" in msg for msg in ooc)
@@ -538,8 +680,7 @@ def test_demo_broadcasts_to_real_clients(monkeypatch):
     area.evi_list.evidences.append(
         EvidenceList.Evidence(
             "demo",
-            "CT#test#hello-from-demo%"
-            "MS#1#-#CM 1##lol#wit#0#1#0#0#0#0#0#0#3# #-1###%",
+            "CT#test#hello-from-demo%" "MS#1#-#CM 1##lol#wit#0#1#0#0#0#0#0#0#3# #-1###%",
             "image",
             "all",
         )
@@ -1068,3 +1209,984 @@ def test_stop_demo_denied_for_cm(monkeypatch):
 
     with pytest.raises(ClientError):
         commands.call(cm, "stop_demo", "")
+
+
+# --- Demo scripting (set/get/labels/goto/if) ---
+
+
+def test_parse_demo_scripting_instructions():
+    from server.script_runner import parse_demo_description
+
+    desc = (
+        "set count 5%"
+        "get need players+2%"
+        "label loop%"
+        "set count count-1%"
+        "if count gt 0 loop%"
+        "goto sub%"
+        "goto done%"
+        "label sub%"
+        "return%"
+        "label done%"
+        "CT#narrator#go%"
+    )
+    instructions = parse_demo_description(desc)
+    assert ("set", "count", "5") in instructions
+    assert ("get", "need", "players+2") in instructions
+    assert ("label", "loop") in instructions
+    assert ("if", "count", "gt", "0", "loop") in instructions
+    assert ("goto", "sub") in instructions
+    assert ("goto", "done") in instructions
+    assert ("return",) in instructions
+    assert ("packet", "CT", ("narrator", "go")) in instructions
+
+
+def test_script_runner_set_get(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("set", "count", "5"), ("set", "count", "count+3"), ("get", "need", "players")])
+    area.clients = {"a", "b", "c"}
+
+    fake_loop.pop_next()  # set count = 5
+    assert area.variables["count"] == 5
+
+    fake_loop.pop_next()  # set count = count + 3
+    assert area.variables["count"] == 8
+
+    fake_loop.pop_next()  # get need = live player count (3 clients)
+    assert area.variables["need"] == 3
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_unknown_variable_stops(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("set", "x", "missing+1")])
+
+    fake_loop.pop_next()
+
+    assert runner.running is False
+    assert any("[Demo] [ERROR] Unknown variable 'missing'" in m for m in area.ooc)
+
+
+def test_script_runner_set_string_literal(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "name", '"Alice"'),
+            ("set", "also", "'Bob'"),
+            ("packet", "CT", ("narrator", "Hello <!name>, from <!also>")),
+        ]
+    )
+
+    fake_loop.pop_next()  # set name = "Alice"
+    assert area.variables["name"] == "Alice"
+
+    fake_loop.pop_next()  # set also = "Bob"
+    assert area.variables["also"] == "Bob"
+
+    fake_loop.pop_next()  # broadcast CT with substituted getters
+    assert area.sent[-1] == ("CT", "narrator", "Hello Alice, from Bob")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_set_copies_variable(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("set", "a", '"hello"'), ("set", "b", "a")])
+
+    fake_loop.pop_next()  # set a = "hello"
+    fake_loop.pop_next()  # set b = a (copy, not expression)
+
+    assert area.variables["a"] == "hello"
+    assert area.variables["b"] == "hello"
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_if_string_eq_branch(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "name", '"Alice"'),
+            ("if", "name", "eq", '"Alice"', "yes"),
+            ("packet", "CT", ("narrator", "not taken")),
+            ("label", "yes"),
+            ("packet", "CT", ("narrator", "taken")),
+        ]
+    )
+
+    fake_loop.pop_next()  # set name = "Alice"
+    fake_loop.pop_next()  # if name == "Alice" -> jump to yes
+    fake_loop.pop_next()  # label yes
+    fake_loop.pop_next()  # broadcast CT "taken"
+
+    assert area.sent[-1] == ("CT", "narrator", "taken")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_if_mixed_compare_stops(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("set", "n", "5"), ("if", "n", "lt", '"5"', "done")])
+
+    fake_loop.pop_next()  # set n = 5
+    fake_loop.pop_next()  # if 5 < "5" -> cannot compare
+
+    assert runner.running is False
+    assert any("Cannot compare a number and a string" in m for m in area.ooc)
+
+
+def test_script_runner_if_symbol_operators(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "n", "3"),
+            ("if", "n", ">=", "5", "done"),
+            ("packet", "CT", ("narrator", "n < 5")),
+            ("set", "n", "n+2"),
+            ("if", "n", ">=", "5", "done"),
+            ("packet", "CT", ("narrator", "unreachable")),
+            ("label", "done"),
+            ("packet", "CT", ("narrator", "n is 5")),
+        ]
+    )
+
+    fake_loop.pop_next()  # set n = 3
+    fake_loop.pop_next()  # if 3 >= 5 -> no jump
+    fake_loop.pop_next()  # broadcast "n < 5"
+    fake_loop.pop_next()  # set n = 5
+    fake_loop.pop_next()  # if 5 >= 5 -> jump to done
+    fake_loop.pop_next()  # label done
+    fake_loop.pop_next()  # broadcast "n is 5"
+
+    assert area.sent[-1] == ("CT", "narrator", "n is 5")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_if_symbol_ne_branch(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "name", '"Alice"'),
+            ("if", "name", "!=", '"Bob"', "yes"),
+            ("packet", "CT", ("narrator", "not taken")),
+            ("label", "yes"),
+            ("packet", "CT", ("narrator", "taken")),
+        ]
+    )
+
+    fake_loop.pop_next()  # set name = "Alice"
+    fake_loop.pop_next()  # if "Alice" != "Bob" -> jump to yes
+    fake_loop.pop_next()  # label yes
+    fake_loop.pop_next()  # broadcast "taken"
+
+    assert area.sent[-1] == ("CT", "narrator", "taken")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_inline_getter_in_packet(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "count", "5"),
+            ("packet", "CT", ("narrator", "I counted <!count>")),
+        ]
+    )
+
+    fake_loop.pop_next()  # set count = 5
+    fake_loop.pop_next()  # broadcast CT with substituted getter
+
+    assert area.variables["count"] == 5
+    assert area.sent[-1] == ("CT", "narrator", "I counted 5")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_inline_getter_in_command(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "score", "10"),
+            ("command", "h", "Score: <!score>"),
+        ]
+    )
+
+    fake_loop.pop_next()  # set score = 10
+    fake_loop.pop_next()  # run command with substituted arg
+
+    assert executor.calls == [("h", "Score: 10")]
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_inline_getter_unknown_stops(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("packet", "CT", ("narrator", "I counted <!count>"))])
+
+    fake_loop.pop_next()
+
+    assert runner.running is False
+    assert any("Unknown variable 'count' in inline getter" in m for m in area.ooc)
+
+
+def test_script_runner_inline_getter_live_source(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("packet", "CT", ("narrator", "<!players> people here"))])
+    area.clients = {"a", "b", "c"}
+
+    fake_loop.pop_next()
+
+    assert area.sent[-1] == ("CT", "narrator", "3 people here")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_inline_getter_live_path(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("packet", "CT", ("narrator", "<!client[0].showname> leads"))])
+    area.clients = {FakeScriptClient(2, "Apollo"), FakeScriptClient(1, "Miles")}
+
+    fake_loop.pop_next()
+
+    assert area.sent[-1] == ("CT", "narrator", "Apollo leads")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_get_client_showname(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "i", "0"),
+            ("get", "showname", "client[i].showname"),
+            ("packet", "CT", ("narrator", "<!showname> is here")),
+        ]
+    )
+    area.clients = {FakeScriptClient(2, "Apollo"), FakeScriptClient(1, "Miles")}
+
+    fake_loop.pop_next()  # set i = 0
+    fake_loop.pop_next()  # get showname = client[0].showname (Apollo, alphabetical)
+    assert area.variables["showname"] == "Apollo"
+    fake_loop.pop_next()  # broadcast CT with getter
+
+    assert area.sent[-1] == ("CT", "narrator", "Apollo is here")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_get_client_index_out_of_range_stops(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("get", "x", "client[5].showname")])
+    area.clients = {FakeScriptClient(1, "Miles")}
+
+    fake_loop.pop_next()
+
+    assert runner.running is False
+    assert any("Client index 5 out of range" in m for m in area.ooc)
+
+
+def test_script_runner_concat(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "list", '""'),
+            ("set", "a", '"Miles"'),
+            ("set", "b", '"Apollo"'),
+            ("concat", "list", "a", '", "'),
+            ("concat", "list", "b", '", "'),
+            ("packet", "CT", ("narrator", "Players: <!list>")),
+        ]
+    )
+
+    fake_loop.pop_next()  # set list = ""
+    fake_loop.pop_next()  # set a = "Miles"
+    fake_loop.pop_next()  # set b = "Apollo"
+    fake_loop.pop_next()  # concat list += "Miles"
+    fake_loop.pop_next()  # concat list += ", Apollo"
+    assert area.variables["list"] == "Miles, Apollo"
+
+    fake_loop.pop_next()  # broadcast CT
+    assert area.sent[-1] == ("CT", "narrator", "Players: Miles, Apollo")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_concat_no_separator(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "tag", '"A"'),
+            ("concat", "tag", '"B"'),
+            ("concat", "tag", '"C"'),
+        ]
+    )
+
+    fake_loop.pop_next()  # set tag = "A"
+    fake_loop.pop_next()  # concat tag += "B"
+    fake_loop.pop_next()  # concat tag += "C"
+
+    assert area.variables["tag"] == "ABC"
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_rand_inclusive_range(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("rand", "roll", "1", "6"),
+            ("packet", "CT", ("narrator", "You rolled <!roll>")),
+        ]
+    )
+
+    fake_loop.pop_next()  # rand roll in [1, 6]
+    roll = area.variables["roll"]
+    assert isinstance(roll, int)
+    assert 1 <= roll <= 6
+
+    fake_loop.pop_next()  # broadcast CT
+    assert area.sent[-1] == ("CT", "narrator", f"You rolled {roll}")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_rand_operand_bounds(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "min", "1"),
+            ("set", "max", "3"),
+            ("rand", "roll", "min", "max"),
+            ("packet", "CT", ("narrator", "<!roll>")),
+        ]
+    )
+
+    fake_loop.pop_next()  # set min = 1
+    fake_loop.pop_next()  # set max = 3
+    fake_loop.pop_next()  # rand roll = random.randint(1, 3)
+    assert 1 <= area.variables["roll"] <= 3
+
+    fake_loop.pop_next()  # broadcast CT
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_rand_bounds_reversed_stops(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("rand", "roll", "6", "1")])
+
+    fake_loop.pop_next()
+
+    assert runner.running is False
+    assert any("rand min 6 is greater than max 1" in m for m in area.ooc)
+
+
+def test_script_runner_rand_non_number_bounds_stops(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("rand", "roll", '"a"', "6")])
+
+    fake_loop.pop_next()
+
+    assert runner.running is False
+    assert any("rand bounds must be numbers" in m for m in area.ooc)
+
+
+def test_script_runner_if_live_path_and_list_visible(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    hidden = FakeScriptClient(2, "Ghost", hidden=True)
+    visible = FakeScriptClient(1, "Miles")
+    area.clients = {hidden, visible}
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "i", "0"),
+            ("get", "total", "clients.count"),
+            ("set", "list", '""'),
+            ("label", "loop"),
+            ("if", "i", "ge", "total", "done"),
+            ("if", "client[i].hidden", "eq", "1", "continue"),
+            ("get", "showname", "client[i].showname"),
+            ("concat", "list", "showname", '", "'),
+            ("label", "continue"),
+            ("set", "i", "i+1"),
+            ("goto", "loop"),
+            ("label", "done"),
+            ("packet", "CT", ("narrator", "Players here: <!list>")),
+        ]
+    )
+
+    for _ in range(30):
+        if not runner.running:
+            break
+        fake_loop.pop_next()
+
+    assert area.variables["list"] == "Miles"
+    assert area.sent[-1] == ("CT", "narrator", "Players here: Miles")
+    assert runner.running is False
+
+
+def test_script_runner_goto_loop(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("set", "count", "3"),
+            ("label", "loop"),
+            ("set", "count", "count-1"),
+            ("if", "count", "gt", "0", "loop"),
+            ("packet", "CT", ("narrator", "done")),
+        ]
+    )
+
+    fake_loop.pop_next()  # set count = 3
+    fake_loop.pop_next()  # label loop (no-op)
+    fake_loop.pop_next()  # set count = 2
+    fake_loop.pop_next()  # if count > 0 -> jump to loop
+    fake_loop.pop_next()  # label loop
+    fake_loop.pop_next()  # set count = 1
+    fake_loop.pop_next()  # if count > 0 -> jump to loop
+    fake_loop.pop_next()  # label loop
+    fake_loop.pop_next()  # set count = 0
+    fake_loop.pop_next()  # if count > 0 -> false, fall through
+    fake_loop.pop_next()  # broadcast CT
+
+    assert area.variables["count"] == 0
+    assert area.sent[-1] == ("CT", "narrator", "done")
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_goto_unknown_label_stops(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("goto", "nope")])
+
+    fake_loop.pop_next()
+
+    assert runner.running is False
+    assert any("Unknown label 'nope'" in m for m in area.ooc)
+
+
+def test_script_runner_goto_return(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("packet", "CT", ("a", "before")),
+            ("goto", "sub"),
+            ("goto", "done"),
+            ("label", "sub"),
+            ("packet", "CT", ("a", "in-sub")),
+            ("return",),
+            ("label", "done"),
+            ("packet", "CT", ("a", "after")),
+        ]
+    )
+
+    fake_loop.pop_next()  # broadcast "before"
+    fake_loop.pop_next()  # goto sub -> push return, jump to sub
+    fake_loop.pop_next()  # label sub (no-op)
+    fake_loop.pop_next()  # broadcast "in-sub"
+    fake_loop.pop_next()  # return -> pop to the goto, which jumps to done
+    fake_loop.pop_next()  # goto done
+    fake_loop.pop_next()  # label done (no-op)
+    fake_loop.pop_next()  # broadcast "after"
+
+    assert [s[2] for s in area.sent] == ["before", "in-sub", "after"]
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_script_runner_return_without_target_stops(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("packet", "CT", ("a", "say")), ("return",)])
+
+    fake_loop.pop_next()  # broadcast "say"
+    fake_loop.pop_next()  # return with empty stack -> script just ends
+
+    assert runner.running is False
+    assert [s[2] for s in area.sent] == ["say"]
+    assert not area.ooc
+
+
+def test_script_runner_if_unknown_op_stops(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("if", "a", "zzz", "1", "loop")])
+
+    fake_loop.pop_next()
+
+    assert runner.running is False
+    assert any("Unknown comparison 'zzz'" in m for m in area.ooc)
+
+
+def test_script_runner_max_steps_stops(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.max_steps = 5
+    runner.start(
+        [
+            ("label", "loop"),
+            ("goto", "loop"),
+        ]
+    )
+
+    for _ in range(6):
+        fake_loop.pop_next()
+
+    assert runner.running is False
+    assert any("Max steps exceeded" in m for m in area.ooc)
+
+
+def test_evaluate_expression_arithmetic():
+    from server.scripting import evaluate_expression, ScriptingError
+
+    assert evaluate_expression("5", {}) == 5
+    assert evaluate_expression("2+3*4", {}) == 14
+    assert evaluate_expression("x+1", {"x": 5}) == 6
+    assert evaluate_expression("x*y-2", {"x": 3, "y": 4}) == 10
+    with pytest.raises(ScriptingError):
+        evaluate_expression("x**2", {})
+    with pytest.raises(ScriptingError):
+        evaluate_expression("unknown_var+1", {})
+    with pytest.raises(ScriptingError):
+        evaluate_expression("1/0", {})
+    with pytest.raises(ScriptingError):
+        evaluate_expression("2 + __import__('os')", {})
+
+
+def test_resolve_value():
+    from server.scripting import resolve_value, ScriptingError
+
+    assert resolve_value('"hello"', {}) == "hello"
+    assert resolve_value("'hello'", {}) == "hello"
+    assert resolve_value('""', {}) == ""
+    assert resolve_value("5", {}) == 5
+    assert resolve_value("2+3", {}) == 5
+    assert resolve_value("x", {"x": "hello"}) == "hello"
+    assert resolve_value("x", {"x": 7}) == 7
+    assert resolve_value("players", {}, {"players": 3}) == 3
+    with pytest.raises(ScriptingError):
+        resolve_value("missing", {})
+
+
+def test_live_sources(make_area):
+    from server.scripting import live_sources
+
+    area = make_area()
+    area.clients = {"a", "b"}
+    area.max_players = 10
+    area.hp_def = 7
+    area.hp_pro = 8
+    sources = live_sources(area)
+    assert sources["players"] == 2
+    assert sources["max_players"] == 10
+    assert sources["hp_def"] == 7
+    assert sources["hp_pro"] == 8
+    assert sources["char_count"] == 1
+    assert "timer0_remaining_ms" not in sources
+
+
+def _filled_area():
+    area = FakeBroadcastArea()
+    area.clients = {
+        FakeScriptClient(3, "Zulu", is_mod=True),
+        FakeScriptClient(1, "Miles"),
+        FakeScriptClient(2, "Apollo", char_id=0),
+    }
+    return area
+
+
+def test_live_get_clients_count_excludes_system():
+    from server.scripting import live_get
+
+    area = FakeBroadcastArea()
+    area.clients = {
+        FakeScriptClient(1, "Miles"),
+        FakeScriptClient(2, "System", ipid=0),
+    }
+    assert live_get("clients.count", area) == 1
+
+
+def test_live_get_client_snapshot_matches_getarea_order():
+    from server.scripting import live_get
+
+    area = _filled_area()
+    area._owners = {next(iter(area.clients))}
+
+    cm = next(c for c in area.clients if c.showname == "Apollo")
+    area._owners = {cm}
+    mod = next(c for c in area.clients if c.showname == "Zulu")
+
+    # /getarea order: normal first (by showname), then CM, then mod.
+    assert live_get("client[0].showname", area) == "Miles"
+    assert live_get("client[1].showname", area) == "Apollo"
+    assert live_get("client[2].showname", area) == "Zulu"
+
+
+def test_live_get_client_fields():
+    from server.scripting import live_get
+
+    area = _filled_area()
+    # /getarea order: Apollo, Miles (normals, alphabetical), then Zulu (mod).
+    assert live_get("client[0].showname", area) == "Apollo"
+    assert live_get("client[0].id", area) == 2
+    assert live_get("client[0].char_id", area) == 0
+    assert live_get("client[0].char_folder", area) == "Char0"
+    assert live_get("client[0].is_cm", area) == 0
+    assert live_get("client[0].iniswap", area) == ""
+    assert live_get("client[0].last_move_time", area) == 0
+    assert live_get("client[0].remote_listen", area) == 2
+    assert live_get("client[0].subtheme", area) == ""
+    assert live_get("client[0].time_of_day", area) == ""
+    assert live_get("client[0].char_url", area) == ""
+    assert live_get("client[0].sneaking", area) == 0
+    assert live_get("client[0].frozen", area) == 0
+    assert live_get("client[2].showname", area) == "Zulu"
+
+
+def test_live_get_index_expression():
+    from server.scripting import live_get
+
+    area = FakeBroadcastArea()
+    area.clients = {FakeScriptClient(1, "Miles"), FakeScriptClient(2, "Apollo")}
+    # Snapshot order: [Apollo, Miles].
+    assert live_get("client[i].showname", area, {"i": 1}) == "Miles"
+    assert live_get("client[i+1].showname", area, {"i": 0}) == "Miles"
+
+
+def test_live_get_area_and_hub_fields(make_area):
+    from server.scripting import live_get
+
+    area = make_area()
+    area.name = "Courtroom"
+    area.max_players = 10
+    area.hp_def = 7
+    area.hp_pro = 8
+    area.desc = "A room"
+    area.pos_lock = ["wit", "stand"]
+    area.music_ref = "court"
+    area.evidence_mod = "FFA"
+    area.area_manager.name = "Test Hub"
+
+    assert live_get("area.name", area) == "Courtroom"
+    assert live_get("area.max_players", area) == 10
+    assert live_get("area.hp_def", area) == 7
+    assert live_get("area.hp_pro", area) == 8
+    assert live_get("area.desc", area) == "A room"
+    assert live_get("area.pos_lock", area) == "wit stand"
+    assert live_get("area.music_ref", area) == "court"
+    assert live_get("area.evidence_mod", area) == "FFA"
+    assert live_get("area.bg_lock", area) == 0
+    assert live_get("area.can_cm", area) == 0
+    assert live_get("area.locked", area) == 0
+    assert live_get("area.music_autoplay", area) == 0
+    hub = area.area_manager
+    hub.music_ref = "court_hub"
+    hub.move_delay = 3
+    hub.char_list_ref = "characters.yaml"
+    hub.info = "A hub description"
+    assert live_get("hub.name", area) == "Test Hub"
+    assert live_get("hub.char_count", area) == 1
+    assert live_get("hub.music_ref", area) == "court_hub"
+    assert live_get("hub.move_delay", area) == 3
+    assert live_get("hub.char_list_ref", area) == "characters.yaml"
+    assert live_get("hub.doc", area) == "A hub description"
+    assert live_get("hub.current_areas", area) == 1
+
+
+def test_live_get_hub_fields_all_readable(make_area):
+    from server.scripting import live_get
+
+    area = make_area()
+    fields = [
+        "name",
+        "abbreviation",
+        "move_delay",
+        "arup_enabled",
+        "hide_clients",
+        "info",
+        "can_gm",
+        "music_ref",
+        "replace_music",
+        "client_music",
+        "max_areas",
+        "single_cm",
+        "can_spectate",
+        "can_getareas",
+        "passing_msg",
+        "autokick_to_latest_area",
+        "char_list_ref",
+        "doc",
+        "char_count",
+        "subtheme",
+        "time_of_day",
+        "current_areas",
+    ]
+    for field in fields:
+        assert live_get(f"hub.{field}", area) is not None, field
+
+
+def test_live_get_area_fields_all_readable(make_area):
+    from server.scripting import live_get
+
+    area = make_area()
+    fields = [
+        "background",
+        "background_suffix",
+        "overlay",
+        "pos_lock",
+        "bg_lock",
+        "overlay_lock",
+        "evidence_mod",
+        "can_cm",
+        "locking_allowed",
+        "iniswap_allowed",
+        "showname_changes_allowed",
+        "shouts_allowed",
+        "jukebox",
+        "abbreviation",
+        "non_int_pres_only",
+        "locked",
+        "muted",
+        "blankposting_allowed",
+        "blankposting_forced",
+        "hp_def",
+        "hp_pro",
+        "doc",
+        "status",
+        "move_delay",
+        "hide_clients",
+        "music_autoplay",
+        "max_players",
+        "desc",
+        "music_ref",
+        "replace_music",
+        "client_music",
+        "music",
+        "music_effects",
+        "music_looping",
+        "ambience",
+        "can_dj",
+        "music_locked",
+        "hidden",
+        "can_whisper",
+        "can_wtce",
+        "can_change_status",
+        "use_backgrounds_yaml",
+        "can_spectate",
+        "can_getarea",
+        "can_cross_swords",
+        "can_scrum_debate",
+        "can_panic_talk_action",
+        "cross_swords_song_start",
+        "cross_swords_song_end",
+        "cross_swords_song_concede",
+        "scrum_debate_song_start",
+        "scrum_debate_song_end",
+        "scrum_debate_song_concede",
+        "panic_talk_action_song_start",
+        "panic_talk_action_song_end",
+        "panic_talk_action_song_concede",
+        "force_sneak",
+        "password",
+        "dark",
+        "background_dark",
+        "pos_dark",
+        "desc_dark",
+        "passing_msg",
+        "msg_delay",
+        "present_reveals_evidence",
+        "ooc_actions_enabled",
+        "can_battle",
+        "auto_pair",
+        "auto_pair_max",
+        "auto_pair_cycle",
+    ]
+    for field in fields:
+        assert live_get(f"area.{field}", area) is not None, field
+
+
+def test_live_get_timer_fields():
+    import arrow
+    import datetime
+
+    from server.scripting import live_get
+
+    area = FakeBroadcastArea()
+    # Hub timer 0: running with 30s left.
+    hub_timer = area.area_manager.timer
+    hub_timer.set = True
+    hub_timer.started = True
+    hub_timer.target = arrow.get() + datetime.timedelta(seconds=30)
+    # Area timer 1: set but paused with 90s on it.
+    area.timers[0].set = True
+    area.timers[0].static = datetime.timedelta(seconds=90)
+
+    assert 29000 <= live_get("timer[0].remaining_ms", area) <= 30000
+    assert live_get("timer[0].started", area) == 1
+    assert live_get("timer[0].set", area) == 1
+    assert live_get("timer[1].remaining_ms", area) == 90000
+    assert live_get("timer[1].started", area) == 0
+    assert live_get("timer[1].static_ms", area) == 90000
+    # Unset timers read as zeros.
+    assert live_get("timer[5].set", area) == 0
+    assert live_get("timer[5].remaining_ms", area) == 0
+
+
+def test_live_get_timer_index_expression():
+    import datetime
+
+    from server.scripting import live_get
+
+    area = FakeBroadcastArea()
+    # timer[4] is the 4th area timer, i.e. area.timers[3].
+    area.timers[3].set = True
+    area.timers[3].static = datetime.timedelta(seconds=7)
+
+    assert live_get("timer[n].remaining_ms", area, {"n": 4}) == 7000
+
+
+def test_live_get_timer_errors():
+    from server.scripting import live_get, ScriptingError
+
+    area = FakeBroadcastArea()
+    with pytest.raises(ScriptingError, match="Timer index 21"):
+        live_get("timer[21].remaining_ms", area)
+    with pytest.raises(ScriptingError, match="Unknown timer field"):
+        live_get("timer[0].bogus_field", area)
+    with pytest.raises(ScriptingError):
+        live_get("timer[1.5].remaining_ms", area)
+
+
+def test_script_runner_get_timer_path(fake_loop):
+    import datetime
+
+    area = FakeBroadcastArea()
+    area.timers[1].set = True
+    area.timers[1].static = datetime.timedelta(seconds=45)
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("get", "left", "timer[2].remaining_ms"),
+            ("packet", "CT", ("narrator", "<!left> ms left")),
+        ]
+    )
+
+    fake_loop.pop_next()  # get left = timer[2].remaining_ms
+    assert area.variables["left"] == 45000
+    fake_loop.pop_next()  # broadcast CT with getter
+    assert area.sent[-1] == ("CT", "narrator", "45000 ms left")
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False
+
+
+def test_live_get_errors():
+    from server.scripting import live_get, ScriptingError
+
+    area = _filled_area()
+    with pytest.raises(ScriptingError):
+        live_get("client[9].showname", area)
+    with pytest.raises(ScriptingError):
+        live_get("client[0].bogus_field", area)
+    for field in ("ipid", "hdid", "is_mod"):
+        with pytest.raises(ScriptingError):
+            live_get(f"client[0].{field}", area)
+    for field in ("music_player", "music_player_ipid"):
+        with pytest.raises(ScriptingError):
+            live_get(f"area.{field}", area)
+    with pytest.raises(ScriptingError):
+        live_get("area.bogus_field", area)
+    with pytest.raises(ScriptingError):
+        live_get("hub.bogus_field", area)
+    with pytest.raises(ScriptingError):
+        live_get("bogus.path", area)
+    with pytest.raises(ScriptingError):
+        live_get("client[1.5].showname", area)
+
+
+def test_script_runner_get_excludes_system_client(fake_loop):
+    area = FakeBroadcastArea()
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start([("get", "total", "clients.count")])
+    area.clients = {
+        FakeScriptClient(1, "Miles"),
+        FakeScriptClient(2, "System", ipid=0),
+    }
+
+    fake_loop.pop_next()
+
+    assert area.variables["total"] == 1
+
+    fake_loop.pop_next()  # queue exhausted
+    assert runner.running is False

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -13,6 +13,7 @@ import pytest
 
 from server import commands
 from server.area import Area
+from server.evidence import EvidenceList
 from server.script_runner import ScriptRunner, parse_demo_description
 from server.timer import Timer
 
@@ -129,6 +130,8 @@ class FakeBroadcastArea:
         self._owners = set()
         self.area_manager = FakeAreaManager()
         self.timers = [Timer(x, area=self) for x in range(20)]
+        self.evi_list = EvidenceList()
+        self.links = {}
 
     def send_command(self, cmd, *args):
         self.sent.append((cmd,) + tuple(args))
@@ -2172,6 +2175,147 @@ def test_live_get_errors():
         live_get("bogus.path", area)
     with pytest.raises(ScriptingError):
         live_get("client[1.5].showname", area)
+
+
+def test_live_get_evidence_fields():
+    from server.scripting import live_get
+
+    area = FakeBroadcastArea()
+    area.evi_list.evidences.append(EvidenceList.Evidence("Letter", "A clue", "letter.png", "all", True, 2, True, False))
+    assert live_get("evidence.count", area) == 1
+    assert live_get("evidence[0].name", area) == "Letter"
+    assert live_get("evidence[0].desc", area) == "A clue"
+    assert live_get("evidence[0].image", area) == "letter.png"
+    assert live_get("evidence[0].pos", area) == "all"
+    assert live_get("evidence[0].can_hide_in", area) == 1
+    assert live_get("evidence[0].show_in_dark", area) == 2
+    assert live_get("evidence[0].can_take", area) == 1
+    assert live_get("evidence[0].editable", area) == 0
+
+
+def test_live_get_evidence_index_expression():
+    from server.scripting import live_get
+
+    area = FakeBroadcastArea()
+    area.evi_list.evidences.append(EvidenceList.Evidence("A", "1", "", "all"))
+    area.evi_list.evidences.append(EvidenceList.Evidence("B", "2", "", "all"))
+    assert live_get("evidence[i].name", area, {"i": 1}) == "B"
+    assert live_get("evidence[0].name", area, {"i": 1}) == "A"
+
+
+def test_live_get_link_fields():
+    from server.scripting import live_get
+
+    area = FakeBroadcastArea()
+    area.links = {
+        "3": {
+            "locked": True,
+            "hidden": False,
+            "target_pos": "stand",
+            "can_peek": True,
+            "evidence": [1, 2],
+            "password": "abc",
+        },
+        "5": {"locked": False, "hidden": True, "target_pos": "", "can_peek": False, "evidence": [], "password": ""},
+    }
+    assert live_get("links.count", area) == 2
+    assert live_get("links[0].target", area) == "3"
+    assert live_get("links[0].locked", area) == 1
+    assert live_get("links[0].hidden", area) == 0
+    assert live_get("links[0].target_pos", area) == "stand"
+    assert live_get("links[0].can_peek", area) == 1
+    assert live_get("links[0].evidence", area) == "1 2"
+    assert live_get("links[0].password", area) == "abc"
+    assert live_get("links[1].target", area) == "5"
+    assert live_get("links[1].locked", area) == 0
+
+
+def test_live_get_evidence_and_link_errors():
+    from server.scripting import live_get, ScriptingError
+
+    area = FakeBroadcastArea()
+    area.evi_list.evidences.append(EvidenceList.Evidence("A", "1", "", "all"))
+    area.links = {
+        "3": {"locked": False, "hidden": False, "target_pos": "", "can_peek": True, "evidence": [], "password": ""}
+    }
+    with pytest.raises(ScriptingError, match="Evidence index"):
+        live_get("evidence[5].name", area)
+    with pytest.raises(ScriptingError, match="Unknown evidence field"):
+        live_get("evidence[0].bogus", area)
+    for field in ("hiding_client", "triggers"):
+        with pytest.raises(ScriptingError):
+            live_get(f"evidence[0].{field}", area)
+    with pytest.raises(ScriptingError, match="Link index"):
+        live_get("links[2].locked", area)
+    with pytest.raises(ScriptingError, match="Unknown link field"):
+        live_get("links[0].bogus", area)
+    with pytest.raises(ScriptingError):
+        live_get("links[1.5].locked", area)
+
+
+def test_script_runner_iterates_evidence(fake_loop):
+    area = FakeBroadcastArea()
+    area.evi_list.evidences.append(EvidenceList.Evidence("Letter", "A", "", "all"))
+    area.evi_list.evidences.append(EvidenceList.Evidence("Badge", "B", "", "all"))
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("get", "count", "evidence.count"),
+            ("set", "i", "0"),
+            ("set", "list", '""'),
+            ("label", "loop"),
+            ("if", "i", "ge", "count", "done"),
+            ("get", "item", "evidence[i].name"),
+            ("concat", "list", "item", '", "'),
+            ("set", "i", "i+1"),
+            ("goto", "loop"),
+            ("label", "done"),
+            ("packet", "CT", ("narrator", "<!list>")),
+        ]
+    )
+    # get count -> set i -> set list -> label -> if (false) -> get -> concat
+    # -> set i -> goto -> label -> if (false) -> get -> concat -> set i -> goto
+    # -> label -> if (true, jump to done) -> label done -> packet -> finish.
+    for _ in range(20):
+        fake_loop.pop_next()
+
+    assert area.variables["count"] == 2
+    assert area.sent[-1] == ("CT", "narrator", "Letter, Badge")
+    assert runner.running is False
+
+
+def test_script_runner_iterates_links(fake_loop):
+    area = FakeBroadcastArea()
+    area.links = {
+        "3": {"locked": True, "hidden": False, "target_pos": "", "can_peek": True, "evidence": [], "password": "abc"},
+        "5": {"locked": False, "hidden": False, "target_pos": "", "can_peek": True, "evidence": [], "password": ""},
+    }
+    executor = FakeExecutor()
+    runner = ScriptRunner(area, executor)
+    runner.start(
+        [
+            ("get", "count", "links.count"),
+            ("set", "i", "0"),
+            ("set", "list", '""'),
+            ("label", "loop"),
+            ("if", "i", "ge", "count", "done"),
+            ("get", "target", "links[i].target"),
+            ("get", "locked", "links[i].locked"),
+            ("concat", "list", "target", '", "'),
+            ("set", "i", "i+1"),
+            ("goto", "loop"),
+            ("label", "done"),
+            ("packet", "CT", ("narrator", "<!list>")),
+        ]
+    )
+    # Same shape as the evidence loop with two iterations: the loop body now
+    # has two `get` instructions, so 20 + 2 = 22 steps total.
+    for _ in range(22):
+        fake_loop.pop_next()
+
+    assert area.sent[-1] == ("CT", "narrator", "3, 5")
+    assert runner.running is False
 
 
 def test_script_runner_get_excludes_system_client(fake_loop):


### PR DESCRIPTION
overhauls the demo, trigger and timer automation systems so that they no longer hijack a pre-existing client but instead leverage the remote_client.py introduced in an admin panel PR previously

This still has to be extremely strategic about how it fakes itself as a client well enough for the commands to be able to run, but for the most part it achieves 1:1 parity with the previously scuffed impelmentation and actually fixes many of the associated bugs due to GM disconnects, wrong-client hijacking, CMs taking higher priority than GMs for some reason, etc.

This also introduces a ScriptRunner engine which decouples a ton of code from other places where they didn't belong. 

Additionally server owners can now modify the /demo command rate limiting and /stop_demo command is also now added. you can do /stop_demo all to stop demo automation in all areas of a hub if you have permissions.